### PR TITLE
adding activesupport back

### DIFF
--- a/cb-api.gemspec
+++ b/cb-api.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7.7'
   s.add_dependency 'nori', '~> 2.2.0'
   s.add_dependency 'nokogiri', '~> 1.6.0'
+  s.add_dependency 'activesupport', '~> 4.0.0'
 
   s.add_development_dependency 'rake', '>= 0.8.7'
   s.add_development_dependency 'webmock', '~> 1.9.0'


### PR DESCRIPTION
When I removed this previously, I still had the gem installed on my box, so the tests all passed and everything was happy. Turns out we actually need this though!
