### PR TITLE
API bug. #552

### DIFF
--- a/cb-api.gemspec
+++ b/cb-api.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '>= 2.11'
   s.add_development_dependency 'rdoc', '~> 3.12.2'
   s.add_development_dependency 'rspec-pride', '~> 2.2.0'
-  s.add_development_dependency 'pry', '~> 0.9.12.1'
+  s.add_development_dependency 'pry', '0.9.12.1'
   s.add_development_dependency 'rb-readline', '~> 0.5.0'
 end

--- a/lib/cb/models/implementations/job.rb
+++ b/lib/cb/models/implementations/job.rb
@@ -97,9 +97,7 @@ module Cb
         @apply_requirements           = Cb::Utils::ResponseArrayExtractor.extract(args, 'ApplyRequirements')
 
         # Company related
-        @company_name                 = args['Company'] || ''
         @company_did                  = args['CompanyDID'] || ''
-        @company_details_url          = args['CompanyDetailsURL'] || ''
         @company_image_url            = args['CompanyImageURL'] || ''
 
         # Recommendations related
@@ -107,8 +105,9 @@ module Cb
         @state                        = args['LocationState'] || ''
         @city                         = args['LocationCity'] || ''
         @zip                          = args['LocationPostalCode'] || ''
-        @company_name                 = args['Company']['CompanyName'] unless args['Company'].nil? || args['Company']['CompanyName'].nil?
-        @company_details_url          = args['Company']['CompanyDetailsURL'] unless args['Company'].nil? || args['Company']['CompanyDetailsURL'].nil?
+
+        @company_name            = figure_out_company_info(args['Company'],args['Company'],'CompanyName')
+        @company_details_url     = figure_out_company_info(args['CompanyDetailsURL'],args['Company'],'CompanyDetailsURL')
 
 
       end
@@ -162,6 +161,24 @@ module Cb
           return @state
         end
       end
+
+      private
+
+      def figure_out_company_info(job_search, recommendation, rec_key)
+        #Job Search and Recommendations both use this class as a model. Unfortunately, they both return company_name and
+        # company_details_url in different ways. Job search returns it in args[company] and args[company_details_url],
+        # but recommendations returns it in args[company][key]. This has been ticketed to the API team, and this logic
+        # will be removed when they have fixed the issue.
+        if job_search.class == String && job_search != ""
+          return job_search
+        elsif recommendation.class == Hash && !recommendation[rec_key].nil?
+          return recommendation[rec_key]
+        else
+          return ''
+        end
+
+      end
+
     end
   end
 end


### PR DESCRIPTION
The api currently returns two different ways of giving us company name and company details url info. This PR fixes our old way of handling them by allowing for nils in one of the returned hashes.

This problem has been brought up with the API team, and we are working with them to fix it entirely, but until then, here's a fix.

JobSearch returns:

```
args[Company] == company name
args[CompanyDetailsURL] == company details url
```

Recs returns

```
args[Company][CompanyName]
args[Company][CompanyDetailsURL]
```
