### PR TITLE
Add custom_apply_type and skip_resume? convenience method

### DIFF
--- a/lib/cb/models/implementations/cb_job.rb
+++ b/lib/cb/models/implementations/cb_job.rb
@@ -10,7 +10,7 @@ module Cb
                   :details_url, :service_url, :similar_jobs_url, :apply_url,
                   :begin_date, :end_date, :posted_date,
                   :relevancy, :state, :city, :zip,
-                  :can_be_quick_applied, :apply_requirements,
+                  :can_be_quick_applied, :apply_requirements, :custom_apply_type,
                   :divison, :industry, :location_street_1, :relocation_options, :location_street_2, :display_job_id,
                   :manages_others_string,
                   :degree_required_code, :travel_required_code, :employment_type_code
@@ -98,6 +98,7 @@ module Cb
       @is_screener_apply            = args['IsScreenerApply'] || ''
       @is_shared_job                = args['IsSharedJob'] || ''
       @can_be_quick_applied         = args['CanBeQuickApplied'] || ''
+      @custom_apply_type            = args['CustomApplyType'] || ''
       @apply_requirements           = Cb::Utils::ResponseArrayExtractor.extract(args, 'ApplyRequirements')
 
       # Company related
@@ -128,27 +129,31 @@ module Cb
     end
 
     def external_application?
-      @external_application.downcase == 'true' ? true : false
+      @external_application.downcase == 'true'
     end
 
     def relocation_covered?
-      @relocation_covered.downcase == 'true' ? true : false
+      @relocation_covered.downcase == 'true'
     end
 
     def manages_others?
-      @manages_others.downcase == 'true' ? true : false
+      @manages_others.downcase == 'true'
     end
 
     def screener_apply?
-      @is_screener_apply.downcase == 'true' ? true : false
+      @is_screener_apply.downcase == 'true'
+    end
+
+    def skip_resume?
+      @custom_apply_type.downcase == 'caskipresume'
     end
 
     def shared_job?
-      @is_shared_job.downcase == 'true' ? true : false
+      @is_shared_job.downcase == 'true'
     end
 
     def can_be_quick_applied?
-      @can_be_quick_applied.downcase == 'true' ? true : false
+      @can_be_quick_applied.downcase == 'true'
     end
     
     def city

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '1.2.4'
+  VERSION = '1.3.4'
 end

--- a/spec/cb/models/cb_job_spec.rb
+++ b/spec/cb/models/cb_job_spec.rb
@@ -4,19 +4,32 @@ module Cb
   describe CbJob do
     describe '#initialize' do
 
-      context 'When ApplyRequirements hash is contained in the hash passed into the constructor' do
-        let(:job_hash) {{
+      context 'With valid response data' do
+        let(:job_response) {{
           'ApplyRequirements' => {
             'ApplyRequirement' => 'noonlineapply'
-          }
+          }, 'CustomApplyType' => 'CASKIPRESUME'
         }}
-        it 'then the apply_requirements field should be set' do
-          job = Cb::CbJob.new job_hash
+        let(:job) { Cb::CbJob.new job_response }
+
+        it 'should set apply_requirements' do
           job.apply_requirements.should == ['noonlineapply']
         end
-        it 'and the ResponseArrayExtractor should have received the message, #extract' do
-          Cb::Utils::ResponseArrayExtractor.should_receive(:extract).with(job_hash, 'ApplyRequirements')
-          Cb::CbJob.new job_hash
+
+        # REFACTOR - improper spec scope
+        it 'should pass appy requirements to the ResponseArrayExtractor' do
+          Cb::Utils::ResponseArrayExtractor.should_receive(:extract).with(job_response, 'ApplyRequirements')
+          Cb::CbJob.new job_response
+        end
+
+        it 'should set custom_apply_type' do
+          job.custom_apply_type.should == 'CASKIPRESUME'
+        end
+
+        describe '#skip_resume?' do
+          it 'should evaluate as true' do
+            expect(job.skip_resume?).to be_true
+          end
         end
       end
       


### PR DESCRIPTION
- Adds custom_apply_type attribute, and a "skip_resume?" convenience method to check on a particular custom apply type
- Remove unnecessary short circuiting if-else in convenience methods
