### PR TITLE
Add 'Test' node to application create/update criteria

### DIFF
--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -1,6 +1,6 @@
 module Cb
   class Config
-    attr_accessor :dev_key, :base_uri, :debug_api, :time_out, :use_json, :host_site, :test_mode,
+    attr_accessor :dev_key, :base_uri, :debug_api, :time_out, :use_json, :host_site, :test_resources,
                   :uri_job_search, :uri_job_find,
                   :uri_company_find, :uri_job_category_search,
                   :uri_education_code, :uri_employee_types,
@@ -125,7 +125,7 @@ module Cb
       @time_out             = 5
       @use_json             = true
       @host_site            = Cb.country.US
-      @test_mode            = false
+      @test_resources       = false
 
       set_default_api_uris
     end

--- a/lib/cb/criteria/application/create.rb
+++ b/lib/cb/criteria/application/create.rb
@@ -36,7 +36,7 @@ module Cb
               }
             end
           }
-          crit[:Test] = true if Cb.configuration.test_mode
+          crit[:Test] = true if Cb.configuration.test_resources
           crit.to_json
         end
       end

--- a/lib/cb/criteria/application/update.rb
+++ b/lib/cb/criteria/application/update.rb
@@ -37,7 +37,7 @@ module Cb
               }
             end
           }
-          crit[:Test] = true if Cb.configuration.test_mode
+          crit[:Test] = true if Cb.configuration.test_resources
           crit.to_json
         end
       end

--- a/spec/cb/criteria/application/create_spec.rb
+++ b/spec/cb/criteria/application/create_spec.rb
@@ -10,12 +10,12 @@ module Cb::Criteria::Application
         end
       end
 
-      context 'when test_mode is enabled' do
-        before { Cb.configuration.test_mode = true }
+      context 'when test_resources is enabled' do
+        before { Cb.configuration.test_resources = true }
         it 'converts the criteria to json' do
           expect(criteria.to_json).to eq(expected_json_with_test)
         end
-        after { Cb.configuration.test_mode = false }
+        after { Cb.configuration.test_resources = false }
       end
     end
 

--- a/spec/cb/criteria/application/update_spec.rb
+++ b/spec/cb/criteria/application/update_spec.rb
@@ -10,12 +10,12 @@ module Cb::Criteria::Application
         end
       end
 
-      context 'when test_mode is enabled' do
-        before { Cb.configuration.test_mode = true }
+      context 'when test_resources is enabled' do
+        before { Cb.configuration.test_resources = true }
         it 'converts the criteria to json' do
           expect(criteria.to_json).to eq(expected_json_with_test)
         end
-        after { Cb.configuration.test_mode = false }
+        after { Cb.configuration.test_resources = false }
       end
     end
 


### PR DESCRIPTION
When 'Cb.configuration.test_resources' is enabled, add the "Test" JSON/XML node to application criteria objects.
