### PR TITLE
Fix class inheritance

### DIFF
--- a/lib/cb/models/implementations/application/form.rb
+++ b/lib/cb/models/implementations/application/form.rb
@@ -1,6 +1,6 @@
 module Cb
   module Models
-    class Application
+    class Application < ApiResponseModel
 
       class Form < ApiResponseModel
         attr_reader :job_did, :job_title, :is_shared_apply, :question_list, :requirements,

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '5.6.0'
+  VERSION = '5.6.1'
 end


### PR DESCRIPTION
For safety's sake, ensure all cases of `Cb::Models::Application` inherit from `ApiResponseModel`
