### PR TITLE
updated dependencies for httparty and json for JDUX team

### DIFF
--- a/cb-api.gemspec
+++ b/cb-api.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['{lib}/**/*.rb', 'LICENSE', '*.md']
   s.require_path = 'lib'
 
-  s.add_dependency 'httparty', '~> 0.11.0'
-  s.add_dependency 'json', '~> 1.7', '>= 1.7.7'
+  s.add_dependency 'httparty', '~> 0.13.0'
+  s.add_dependency 'json', '~> 1.8.1', '>= 1.8.1'
   s.add_dependency 'nori', '~> 2.2.0'
 
   s.add_development_dependency 'rake', '>= 0.8.7'


### PR DESCRIPTION
Hello fellow CB engineers. We here on the JDUX team under Alex Histrov are currently working on leveraging this gem to pull categories from the category api. We are running into some issues where the dependencies in the cb-api gem are behind the gems we currently have in our app, specifically (httparty and json). We want these dependencies updated to prevent having to roll back to an earlier version of these gems. Please let us know if this is possible and if its not please submit these changes and email Jarvis.Hambrick@careerbuilder.com when complete. Thanks   
