### PR TITLE
fix potential nil incoming on ipath for application external api

### DIFF
--- a/lib/cb/models/implementations/application_external.rb
+++ b/lib/cb/models/implementations/application_external.rb
@@ -9,7 +9,7 @@ module Cb
         @job_did                = args[:job_did] || ''
         @email                  = args[:email] || ''
         @site_id                = args[:site_id] || 'cbnsv'
-        @ipath                  = args[:ipath].slice(0,IPATH_LENGTH) || ''
+        @ipath                  = args[:ipath].slice(0, IPATH_LENGTH) rescue ''
         @is_external_link_apply = args[:is_external_link_apply] || false
         @apply_url              = ''
       end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '7.6.0'
+  VERSION = '7.6.1'
 end

--- a/spec/cb/models/implementations/application_external_spec.rb
+++ b/spec/cb/models/implementations/application_external_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 module Cb::Models
+
   describe ApplicationExternal do
 
     before :all do
@@ -20,11 +21,22 @@ module Cb::Models
 
     context '#new' do
       it 'should create an empty new external application' do
+        application = ApplicationExternal.new
+        expect(application.job_did).to eq ''
+        expect(application.email).to eq ''
+        expect(application.ipath).to eq ''
+        expect(application.is_external_link_apply).to eq false
+        expect(application.site_id).to eq 'cbnsv'
+        expect(application.apply_url).to eq ''
+      end
+
+      it 'should create a populated external application' do
         expect(@application.job_did).to eq @job_did
         expect(@application.email).to eq @email
         expect(@application.ipath).to eq 'shivitands'
         expect(@application.is_external_link_apply).to eq @is_external_link_apply
         expect(@application.site_id).to eq @site_id
+        expect(@application.apply_url).to eq ''
       end
     end
 
@@ -35,6 +47,6 @@ module Cb::Models
       end
     end
 
-
   end
+
 end


### PR DESCRIPTION
- When ipath comes in as `nil` on the `args` hash, we try and slice and get a `no_method_error`!
- Adding a test for the instantiation of `ApplicationExternal` model.
