### PR TITLE
update user delete account to get errors

### DIFF
--- a/lib/cb/clients/user.rb
+++ b/lib/cb/clients/user.rb
@@ -46,13 +46,14 @@ module Cb
         end
 
         def delete(external_id, password, test_mode = false)
-          result = false
+          result = Cb::Utils::MetaValues.new
           my_api = Cb::Utils::Api.instance
           json_hash = my_api.cb_post Cb.configuration.uri_user_delete, :body => build_delete_request(external_id, password, test_mode)
 
           if json_hash.has_key? 'ResponseUserDelete'
             if json_hash['ResponseUserDelete'].has_key?('Status') && json_hash['ResponseUserDelete']['Status'].include?('Success')
-              result = true
+              result.class.send(:attr_reader, 'success')
+              result.instance_variable_set(:@success, 'true')
             end
             my_api.append_api_responses result, json_hash['ResponseUserDelete']
           end


### PR DESCRIPTION
As a jobseeker I want to delete my profile So that I no longer exist at CareerBuilder - https://careerbuilder.mingle.thoughtworks.com/projects/engagement__new_/cards/139

Api wrapper already exists but does not handle error message, the delete method just return true or false. Returns now a MetaValues object
