### PR TITLE
adding case for job model property pay to catch job result pay field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 14.0.2 Added case for Job model "pay" when setting model properties
+         so job search result pay field would be added to response as well
 * 14.0.1 Introduced a changelog (finally)
 * 14.0.0 Rename location_code / zip to postal_code on the Cb::Models::User model to be more i18n friendly
 * 13.0.1 This change is to turn off metadata parsing and raise exception if the api response does not contain metadata.

--- a/lib/cb/models/implementations/job.rb
+++ b/lib/cb/models/implementations/job.rb
@@ -103,7 +103,7 @@ module Cb
         @display_job_id               = args['DisplayJobID'] || ''
 
         # Compensation
-        @pay                          = args['PayHighLowFormatted'] || ''
+        @pay                          = args['PayHighLowFormatted'] || args['Pay'] || ''
         @pay_per                      = args['PayPer'] || ''
         @commission                   = args.has_key?("PayCommission") && !args["PayCommission"].nil? ? args['PayCommission']['Money']['FormattedAmount'] : ''
         @bonus                        = args.has_key?("PayBonus") && !args["PayBonus"].nil? ? args['PayBonus']['Money']['FormattedAmount'] : ''

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '14.0.1'
+  VERSION = '14.0.2'
 end


### PR DESCRIPTION
The job model is shared for job details and job search results. The pay field was not being set when it was a job search result response since the field is called "Pay" and there was no case for this.
