### PR TITLE
Improve timing collection and granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.2.0 Collect API caller info a level above lib/cb/client.rb and get timings on errors as well.
 * 18.1.0 Adding report a job endpoint
 * 18.0.2 Updating contact info in the gemspec
 * 18.0.1 Adding job search version 3 query parameters

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -119,9 +119,13 @@ module Cb
       def find_api_caller(call_list)
         filename_regex = /.*\.rb/
         linenum_regex = /:.*:in `/
-        filename, method_name = call_list.find { |l| l[filename_regex] != __FILE__ }[0..-2].split(linenum_regex)
+        filename, method_name = call_list.find { |l| use_this_api_caller?(l[filename_regex]) }[0..-2].split(linenum_regex)
         simplified_filename = filename.include?('/lib/') ? filename[/\/lib\/.*/] : filename
         { file: simplified_filename, method: method_name }
+      end
+
+      def use_this_api_caller?(calling_file)
+        (calling_file == __FILE__ || calling_file.include?('/lib/cb/client.rb')) ? false : true
       end
 
       def validate_response(response)

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -57,10 +57,14 @@ module Cb
       def execute_http_request(http_method, uri, path, options = {}, &block)
         self.class.base_uri(uri || Cb.configuration.base_uri)
         api_caller = find_api_caller(caller)
+        response = nil
         start_time = Time.now.to_f
-        cb_event(:"cb_#{ http_method }_before", path, options, api_caller, nil, 0.0, &block)
-        response = self.class.method(http_method).call(path, options)
-        cb_event(:"cb_#{ http_method }_after", path, options, api_caller, response, Time.now.to_f - start_time, &block)
+        cb_event(:"cb_#{ http_method }_before", path, options, api_caller, response, 0.0, &block)
+        begin
+          response = self.class.method(http_method).call(path, options)
+        ensure
+          cb_event(:"cb_#{ http_method }_after", path, options, api_caller, response, Time.now.to_f - start_time, &block)
+        end
         validate_response(response)
       end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '18.1.0'
+  VERSION = '18.2.0'
 end

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -9,7 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
-require_relative '../../support/mocks/observer'
+require 'support/mocks/request'
+require 'support/mocks/response'
+require 'support/mocks/observer'
 module Cb
   module Utils
     describe Api do
@@ -49,10 +51,10 @@ module Cb
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              nil, 0.0).at_most(1).times.and_call_original
+                                                              nil, 0.0).once.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+                                                              { success: 'yeah' }, instance_of(Float)).once.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).twice
             api.cb_get(path)
           end
@@ -66,12 +68,30 @@ module Cb
               expect(api).to receive(:notify_observers).twice.and_call_original
               expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_before, '/moom', {},
                                                                 { file: __FILE__, method: 'block (6 levels) in <module:Utils>' },
-                                                                nil, 0.0).at_most(1).times.and_call_original
+                                                                nil, 0.0).once.and_call_original
               expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_after, '/moom', {},
                                                                 { file: __FILE__, method: 'block (6 levels) in <module:Utils>' },
-                                                                nil, instance_of(Float)).at_most(1).times.and_call_original
+                                                                nil, instance_of(Float)).once.and_call_original
               expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).twice
               expect { api.cb_get(path) }.to raise_error(StandardError)
+            end
+          end
+
+          context 'called from cb/client' do
+            before do
+              allow(Api).to receive(:get).and_return({})
+              allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
+            end
+
+            it 'still identifies the spec file as the caller' do
+              expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_before, instance_of(String), instance_of(Hash),
+                                                                { file: __FILE__, method: 'block (5 levels) in <module:Utils>' },
+                                                                nil, 0.0).once.and_call_original
+              expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_after, instance_of(String), instance_of(Hash),
+                                                                { file: __FILE__, method: 'block (5 levels) in <module:Utils>' },
+                                                                {}, instance_of(Float)).once.and_call_original
+              expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).twice
+              Cb::Client.new.execute(Mocks::Request.new(:get))
             end
           end
         end
@@ -119,10 +139,10 @@ module Cb
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_post_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              nil, 0.0).at_most(1).times.and_call_original
+                                                              nil, 0.0).once.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_post_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+                                                              { success: 'yeah' }, instance_of(Float)).once.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_post(path)
           end
@@ -171,10 +191,10 @@ module Cb
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_put_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              nil, 0.0).at_most(1).times.and_call_original
+                                                              nil, 0.0).once.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_put_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+                                                              { success: 'yeah' }, instance_of(Float)).once.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_put(path)
           end
@@ -224,10 +244,10 @@ module Cb
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_delete_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              nil, 0.0).at_most(1).times.and_call_original
+                                                              nil, 0.0).once.and_call_original
             expect(Cb::Models::ApiCall).to receive(:new).with(:cb_delete_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
-                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+                                                              { success: 'yeah' }, instance_of(Float)).once.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_delete(path)
           end


### PR DESCRIPTION
Today we are collecting API timings, but have instances in our code where we are calling through the additional `lib/cb/client.rb` that exists in this project. This is not useful to us, so we are going to dig a level beyond that file to see who's calling it.

Also move the observer notification to a `begin...ensure` block to avoid losing the timings around errors. This is still valuable information to know and should impact our API timings dashboard numbers.