### PR TITLE
Method renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.2.1 No functional changes, just renamed `execute_http_request` to `timed_http_request`.
 * 18.2.0 Collect API caller info a level above lib/cb/client.rb and get timings on errors as well.
 * 18.1.0 Adding report a job endpoint
 * 18.0.2 Updating contact info in the gemspec

--- a/lib/cb/client.rb
+++ b/lib/cb/client.rb
@@ -25,7 +25,7 @@ module Cb
     private
 
     def call_api(request)
-      http_wrapper.execute_http_request(
+      http_wrapper.timed_http_request(
         request.http_method,
         request.base_uri,
         request.endpoint_uri,

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -67,6 +67,11 @@ module Cb
         validate_response(response)
       end
 
+      def execute_http_request(http_method, uri, path, options = {})
+        self.class.base_uri(uri || Cb.configuration.base_uri)
+        self.class.method(http_method).call(path, options)
+      end
+
       def append_api_responses(obj, resp)
         meta_class = ensure_non_nil_metavalues(obj)
 
@@ -114,11 +119,6 @@ module Cb
       end
 
       private
-
-      def execute_http_request(http_method, uri, path, options = {})
-        self.class.base_uri(uri || Cb.configuration.base_uri)
-        self.class.method(http_method).call(path, options)
-      end
 
       def find_api_caller(call_list)
         filename_regex = /.*\.rb/

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -60,7 +60,7 @@ module Cb
         start_time = Time.now.to_f
         cb_event(:"cb_#{ http_method }_before", path, options, api_caller, response, 0.0, &block)
         begin
-          response = execute_http_request(http_method, uri, path, options, &block)
+          response = execute_http_request(http_method, uri, path, options)
         ensure
           cb_event(:"cb_#{ http_method }_after", path, options, api_caller, response, Time.now.to_f - start_time, &block)
         end
@@ -115,7 +115,7 @@ module Cb
 
       private
 
-      def execute_http_request(http_method, uri, path, options = {}, &block)
+      def execute_http_request(http_method, uri, path, options = {})
         self.class.base_uri(uri || Cb.configuration.base_uri)
         self.class.method(http_method).call(path, options)
       end

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -39,29 +39,28 @@ module Cb
       end
 
       def cb_get(path, options = {}, &block)
-        execute_http_request(:get, nil, path, options, &block)
+        timed_http_request(:get, nil, path, options, &block)
       end
 
       def cb_post(path, options = {}, &block)
-        execute_http_request(:post, nil, path, options, &block)
+        timed_http_request(:post, nil, path, options, &block)
       end
 
       def cb_put(path, options = {}, &block)
-        execute_http_request(:put, nil, path, options, &block)
+        timed_http_request(:put, nil, path, options, &block)
       end
 
       def cb_delete(path, options = {}, &block)
-        execute_http_request(:delete, nil, path, options, &block)
+        timed_http_request(:delete, nil, path, options, &block)
       end
 
-      def execute_http_request(http_method, uri, path, options = {}, &block)
-        self.class.base_uri(uri || Cb.configuration.base_uri)
+      def timed_http_request(http_method, uri, path, options = {}, &block)
         api_caller = find_api_caller(caller)
         response = nil
         start_time = Time.now.to_f
         cb_event(:"cb_#{ http_method }_before", path, options, api_caller, response, 0.0, &block)
         begin
-          response = self.class.method(http_method).call(path, options)
+          response = execute_http_request(http_method, uri, path, options, &block)
         ensure
           cb_event(:"cb_#{ http_method }_after", path, options, api_caller, response, Time.now.to_f - start_time, &block)
         end
@@ -115,6 +114,11 @@ module Cb
       end
 
       private
+
+      def execute_http_request(http_method, uri, path, options = {}, &block)
+        self.class.base_uri(uri || Cb.configuration.base_uri)
+        self.class.method(http_method).call(path, options)
+      end
 
       def find_api_caller(call_list)
         filename_regex = /.*\.rb/

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '18.2.0'
+  VERSION = '18.2.1'
 end

--- a/spec/cb/client_spec.rb
+++ b/spec/cb/client_spec.rb
@@ -51,7 +51,7 @@ module Cb
 
       context 'post' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return({})
+          allow(mock_api).to receive(:timed_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -60,7 +60,7 @@ module Cb
         end
 
         it 'should call the api using post' do
-          expect(mock_api).to receive(:execute_http_request)
+          expect(mock_api).to receive(:timed_http_request)
             .with(:post, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
             .and_return({})
 
@@ -70,7 +70,7 @@ module Cb
 
       context 'get' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return({})
+          allow(mock_api).to receive(:timed_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -79,7 +79,7 @@ module Cb
         end
 
         it 'should call the api using get' do
-          expect(mock_api).to receive(:execute_http_request)
+          expect(mock_api).to receive(:timed_http_request)
             .with(:get, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
             .and_return({})
 
@@ -89,7 +89,7 @@ module Cb
 
       context 'put' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return({})
+          allow(mock_api).to receive(:timed_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -98,7 +98,7 @@ module Cb
         end
 
         it 'should call the api using put' do
-          expect(mock_api).to receive(:execute_http_request)
+          expect(mock_api).to receive(:timed_http_request)
             .with(:put, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
             .and_return({})
 
@@ -115,7 +115,7 @@ module Cb
 
       context 'post' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return({})
+          allow(mock_api).to receive(:timed_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -124,7 +124,7 @@ module Cb
         end
 
         it 'should call the api using post' do
-          expect(mock_api).to receive(:execute_http_request)
+          expect(mock_api).to receive(:timed_http_request)
             .with(:post, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
             .and_yield('test')
             .and_return({})
@@ -135,7 +135,7 @@ module Cb
 
       context 'get' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return({})
+          allow(mock_api).to receive(:timed_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -144,7 +144,7 @@ module Cb
         end
 
         it 'should call the api using get' do
-          expect(mock_api).to receive(:execute_http_request)
+          expect(mock_api).to receive(:timed_http_request)
             .with(:get, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
             .and_yield('test')
             .and_return({})
@@ -155,7 +155,7 @@ module Cb
 
       context 'put' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return({})
+          allow(mock_api).to receive(:timed_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -164,7 +164,7 @@ module Cb
         end
 
         it 'should call the api using put' do
-          expect(mock_api).to receive(:execute_http_request)
+          expect(mock_api).to receive(:timed_http_request)
             .with(:put, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
             .and_yield('test')
             .and_return({})

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -285,7 +285,7 @@ module Cb
         end
       end
 
-      describe '#execute_http_request' do
+      describe '#timed_http_request' do
         context ':delete' do
           context 'when we have observers' do
             let(:response) { { success: 'yeah' } }
@@ -297,13 +297,13 @@ module Cb
             it 'will notify the observers' do
               expect(api).to receive(:notify_observers).twice.and_call_original
               expect(observer).to receive(:update).at_most(2).times
-              api.execute_http_request(:delete, nil, path)
+              api.timed_http_request(:delete, nil, path)
             end
           end
 
           it 'sends #delete to HttParty' do
             expect(Api).to receive(:delete).with(path, options)
-            api.execute_http_request(:delete, nil, path)
+            api.timed_http_request(:delete, nil, path)
           end
 
           context 'When Cb base_uri is configured' do
@@ -313,7 +313,7 @@ module Cb
             end
 
             it 'sets base_uri on Api' do
-              api.execute_http_request(:delete, nil, path)
+              api.timed_http_request(:delete, nil, path)
 
               expect(Api.base_uri).to eq 'http://www.kylerox.org'
             end
@@ -328,7 +328,7 @@ module Cb
 
             it 'sends #validate to ResponseValidator with the response' do
               expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
-              api.execute_http_request(:delete, nil, path)
+              api.timed_http_request(:delete, nil, path)
             end
           end
         end
@@ -345,7 +345,7 @@ module Cb
 
         context 'passes a base uri' do
           before do
-            api.execute_http_request(:delete, base_uri, path)
+            api.timed_http_request(:delete, base_uri, path)
           end
 
           it 'sets an override' do
@@ -355,7 +355,7 @@ module Cb
 
         context 'passes nil' do
           before do
-            api.execute_http_request(:delete, nil, path)
+            api.timed_http_request(:delete, nil, path)
           end
 
           it 'doesn\'t set an override' do


### PR DESCRIPTION
`execute_http_request` -> `timed_http_request` for better naming of what the method's responsibilities are. Also broke out the actual execution of the http request from the `timed_http_request` method for clarity.