### PR TITLE
Introduce a base client object to inherit from

### DIFF
--- a/lib/cb.rb
+++ b/lib/cb.rb
@@ -35,3 +35,15 @@ module Cb
     @configuration
   end
 end
+
+Dir[File.join(File.dirname(__FILE__), 'cb/client/*')].each { |file| require file }
+
+module CB
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= CB::Config.new
+  end
+end

--- a/lib/cb/client/base.rb
+++ b/lib/cb/client/base.rb
@@ -1,0 +1,114 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'cb/models/api_info'
+
+require 'httparty'
+require 'observer'
+
+module CB
+  module Client
+    class MissingParams < StandardError; end
+
+    class Base
+      include HTTParty, Observable
+      base_uri 'https://api.careerbuilder.com'
+      DEFAULT_TIMEOUT = 15
+
+      attr_reader :default_params, :headers, :timeout
+
+      def initialize(config = {})
+        modify_base_uri(config[:uri] || CB.configuration.uri)
+        set_default_params(config[:default_params])
+        set_headers(config[:headers])
+        set_timeout(config[:timeout])
+        tack_on_observers(config[:observers] || CB.configuration.observers)
+      end
+
+      private
+
+      [:get, :post, :put, :delete, :head].each do |verb|
+        define_method(verb) do |path, opts|
+          start_time = Time.now.to_f
+          opts.merge!(default_params: @default_params, headers: @headers, timeout: @timeout)
+          before_request(self, verb, path, opts)
+          begin
+            resp = self.class.public_send(verb, path, opts)
+          ensure
+            after_request(self, verb, path, opts, resp, Time.now.to_f - start_time)
+          end
+          resp
+        end
+      end
+
+      def modify_base_uri(uri)
+        self.class.base_uri(uri) if uri
+      end
+
+      def set_default_params(params)
+        @default_params ||= {}
+        @default_params = shallow_symbolize_hash_keys(params) if params.is_a?(Hash)
+        unless @default_params.has_key?(:developerkey) || CB.configuration.dev_key == CB::Config::DEV_KEY_DEFAULT
+          @default_params.merge!(developerkey: CB.configuration.dev_key)
+        end
+        fail MissingParams.new(:developerkey) unless @default_params.has_key?(:developerkey)
+      end
+
+      def set_headers(h)
+        @headers ||= {}
+        @headers = shallow_stringify_hash_keys(h) if h.is_a?(Hash)
+      end
+
+      def set_timeout(t)
+        @timeout ||= DEFAULT_TIMEOUT
+        @timeout = t if t && (t.is_a?(Fixnum) || t.is_a?(Float))
+      end
+
+      def shallow_symbolize_hash_keys(h)
+        h.inject({}) { |memo, (k, v)| memo[k.to_sym] = v; memo }
+      end
+
+      def shallow_stringify_hash_keys(h)
+        h.inject({}) { |memo, (k, v)| memo[k.to_s] = v; memo }
+      end
+
+      def tack_on_observers(observers)
+        if observers.is_a?(Array)
+          observers.each do |klass|
+            add_observer(klass)
+          end
+        end
+      end
+
+      def generate_api_info(stage, verb, path, options, klass, response, elapsed_time)
+        api_caller = [klass.class.name, verb.upcase, path].join(';')
+        name = :"cb_#{ verb }_#{ stage }"
+        CB::Models::APIInfo.new(name, path, options, api_caller, response, elapsed_time)
+      end
+
+      def before_request(klass, verb, path, options)
+        api_event(generate_api_info('before', verb, path, options, klass, nil, 0.0))
+      end
+
+      def after_request(klass, verb, path, options, response, elapsed_time)
+        api_event(generate_api_info('after', verb, path, options, klass, response, elapsed_time))
+      end
+
+      def api_event(api_info)
+        changed
+        notify_observers(api_info)
+      end
+
+      def query_plus_host_site(host_site, query = {})
+        { hostsite: (host_site.nil? || host_site.empty?) ? CB.configuration.host_site : host_site }.merge(query)
+      end
+    end
+  end
+end

--- a/lib/cb/client/company.rb
+++ b/lib/cb/client/company.rb
@@ -1,0 +1,23 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'cb/client/base'
+
+module CB
+  module Client
+    class Company < CB::Client::Base
+      COMPANY_DETAILS_ENDPOINT = '/Employer/CompanyDetails'
+
+      def find_by_did(did, host_site = '')
+        get(COMPANY_DETAILS_ENDPOINT, query: query_plus_host_site(host_site, CompanyDID: did))
+      end
+    end
+  end
+end

--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -112,3 +112,24 @@ module Cb
     end
   end
 end
+
+module CB
+  class Config
+    attr_accessor :dev_key, :uri, :observers, :host_site
+
+    DEV_KEY_DEFAULT = 'ruby-cb-api'
+
+    def initialize
+      set_defaults
+    end
+
+    protected
+
+    def set_defaults
+      @dev_key              = DEV_KEY_DEFAULT  # Get a developer key at http://api.careerbuilder.com
+      @uri                  = 'https://api.careerbuilder.com'
+      @host_site            = 'US'
+      @observers            = []
+    end
+  end
+end

--- a/lib/cb/models/api_info.rb
+++ b/lib/cb/models/api_info.rb
@@ -1,0 +1,16 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+module CB
+  module Models
+    class APIInfo < Struct.new(:api_call_type, :path, :options, :api_caller, :response, :elapsed_time)
+    end
+  end
+end

--- a/spec/cb/client/base_spec.rb
+++ b/spec/cb/client/base_spec.rb
@@ -1,0 +1,190 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module CB::Client
+  describe Base do
+    context 'create client instance verifies required settings' do
+      let(:base_valid_params) { { default_params: { developerkey: '123' } } }
+
+      context 'succeeds to create base client' do
+        let(:params) { base_valid_params }
+        let(:client) { Base.new(params) }
+
+        it 'with correct settings' do
+          expect(client).to be_a(Base)
+          expect(client.default_params).to eq(params[:default_params])
+          expect(client.headers).to eq({})
+          expect(client.timeout).to eq(15)
+        end
+      end
+
+      context '#default_params' do
+        let(:client) { Base.new(params) }
+
+        context 'is not a hash' do
+          let(:params) { { default_params: 1 } }
+
+          it 'raises the missing params error for developerkey' do
+            expect { Base.new(params) }.to raise_error(MissingParams, 'developerkey')
+          end
+        end
+
+        context 'is a hash without required key' do
+          let(:params) { { default_params: { other_key: :other_value } } }
+
+          it 'raises the missing params error for developerkey' do
+            expect { Base.new(params) }.to raise_error(MissingParams, 'developerkey')
+          end
+        end
+
+        context 'is a hash with required key' do
+          let(:params) { base_valid_params }
+
+          it 'successfully creates the client with developerkey' do
+            expect(client.default_params).to eq(params[:default_params])
+          end
+        end
+
+        context 'is a hash with required key, but as a string' do
+          let(:params) { { default_params: { 'developerkey' => '123' } } }
+
+          it 'successfully creates the client with developerkey and converts the key to a symbol' do
+            expect(client.default_params).to eq(base_valid_params[:default_params])
+          end
+        end
+
+        context 'required key is not present but is present in CB.configuration' do
+          let(:params) { { default_params: {} } }
+          let(:config) { CB::Config.new }
+
+          before do
+            config.dev_key = 'ABC'
+            allow(CB).to receive(:configuration).and_return(config)
+          end
+
+          it 'abc' do
+            expect(client.default_params).to eq(developerkey: 'ABC')
+          end
+        end
+      end
+
+      context '#headers' do
+        let(:client) { Base.new(params) }
+
+        context 'is not a hash' do
+          let(:params) { base_valid_params.merge(headers: 1) }
+
+          it 'gracefully handles meaningless #headers options' do
+            expect(client.headers).to eq({})
+          end
+        end
+
+        context 'is a hash' do
+          let(:params) { base_valid_params.merge(headers: { rando: :header }) }
+
+          it 'successfully adds the #headers with string keys' do
+            expect(client.headers['rando']).to eq(params[:headers][:rando])
+          end
+        end
+      end
+
+      context '#timeout' do
+        let(:client) { Base.new(params) }
+
+        context 'is not a number' do
+          let(:params) { base_valid_params.merge(timeout: '123') }
+
+          it 'gracefully handles meaningless #timeout option' do
+            expect(client.timeout).to eq(Base::DEFAULT_TIMEOUT)
+          end
+        end
+
+        context 'is a number' do
+          let(:params) { base_valid_params.merge(timeout: 1) }
+
+          it 'successfully sets the timeout' do
+            expect(client.timeout).to eq(params[:timeout])
+          end
+        end
+      end
+    end
+
+    context 'client requests from the base class' do
+      class FakeClient < Base
+        def fake
+          get('/fake', {})
+        end
+      end
+
+      let(:client) { FakeClient.new({ default_params: { developerkey: '123' } }) }
+
+      before do
+        stub_request(:get, %r{https://api.careerbuilder.com/fake.*})
+          .to_return(status: 200, body: '{}',
+                     headers: { 'content-type' => ['application/json; charset=utf-8'] })
+      end
+
+      context 'successful request' do
+        it { expect(client.fake.success?).to eq(true) }
+        it { expect(client.fake.parsed_response).to eq({}) }
+      end
+
+      context 'failed request' do
+        context 'with a 500' do
+          before do
+            stub_request(:get, %r{https://api.careerbuilder.com/fake.*})
+              .to_return(status: 500, body: '{}',
+                         headers: { 'content-type' => ['application/json; charset=utf-8'] })
+          end
+
+          it { expect(client.fake.success?).to eq(false) }
+          it { expect(client.fake.parsed_response).to eq({}) }
+        end
+
+        context 'with a timeout' do
+          before do
+            stub_request(:get, %r{https://api.careerbuilder.com/fake.*}).to_timeout
+          end
+
+          it { expect { client.fake }.to raise_error(Timeout::Error) }
+        end
+      end
+
+      context 'observers' do
+        class FakeObserver
+          def update(api_call)
+          end
+        end
+
+        RSpec::Matchers.define :cb_models_apiinfo do |stage|
+          match { |actual| actual.api_call_type.to_s == "cb_get_#{ stage }" }
+          match { |actual| actual.path == '/fake' }
+          match { |actual| actual.api_caller == 'CB::Client::FakeClient;GET;/fake' }
+        end
+
+        let(:observer) { FakeObserver.new }
+        let(:config) { CB::Config.new }
+
+        before do
+          config.observers = [observer]
+          allow(CB).to receive(:configuration).and_return(config)
+        end
+
+        it 'are correctly notified' do
+          expect(observer).to receive(:update).with(cb_models_apiinfo('before'))
+          expect(observer).to receive(:update).with(cb_models_apiinfo('after'))
+          client.fake
+        end
+      end
+    end
+  end
+end

--- a/spec/cb/client/company_spec.rb
+++ b/spec/cb/client/company_spec.rb
@@ -1,0 +1,58 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module CB
+  describe CB::Client::Company do
+    def stub_api_response_to_return(content)
+      stub_request(:get, uri_stem(CB::Client::Company::COMPANY_DETAILS_ENDPOINT))
+        .to_return(body: content.to_json)
+    end
+
+    let(:client) { CB::Client::Company.new(default_params: { developerkey: '123' }) }
+
+    context '#find_by_did' do
+      context 'when the API response has all required nodes' do
+        let(:content) do
+          {
+            Results: {
+              CompanyProfileDetail: {
+                CompanyPhotos: { PhotoList: [] },
+                CompanyBulletinBoard: { bulletinboards: {} },
+                Testimonials: { Testimonials: [] },
+                CompanyLinksCollection: { companylinks: [] },
+                MyContent: { MyContentTabs: [] },
+                InfoTabs: { InfoTabs: [] }
+              }
+            }
+          }
+        end
+
+        before do
+          stub_api_response_to_return(content)
+        end
+
+        it 'returns a single company model' do
+          res = client.find_by_did('fake-did').parsed_response
+          expect(res).to eq(content.to_json)
+        end
+      end
+
+      context 'when the API response is an empty hash' do
+        before { stub_api_response_to_return({}) }
+
+        it 'we get the empty hash' do
+          expect(client.find_by_did('fake-did').parsed_response).to eq('{}')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thought process: Move towards individually configured clients per type of request that inherit from this base class. Each client will be able to use their own dev key, their own headers, and even be pointed at different URIs if we so desire.

This client should not care about what the response is though. It should simply get a response and hand it off to the user of the base client. A future PR will debate whether the individual clients should care about the structure of the response object and where the mapping of the data within should be done.

This is going against a feature branch and introduces a new namespace of `CB` as opposed to `Cb`, which is used today. Note about the namespace addition, it should allow us to have both existing simultaneously should we decide to move forward with my proposed direction.