### PR TITLE
Similar jobs company

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.5.1 Fixed the deserialization of the response from job recs for a company did.
 * 18.5.0 Adding support for Cover Letter Update.
 * 18.4.0 Adding support for Cover Letter APIs - Retrieve, List, and Delete.
 * 18.3.0 Correcting report a job to use xml request and correctly map model from response.

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -67,8 +67,8 @@ module Cb
         json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
         jobs = []
         if json_hash.key?('Results')
-          if json_hash['Results'].key?('JobRecommendation')
-            json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
+          if json_hash['Results'].key?('JobRecommendation') && json_hash['Results']['JobRecommendation'].key?('Jobs')
+                json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
               jobs << Models::Job.new(cur_job)
             end
             my_api.append_api_responses(jobs, json_hash['Results']['JobRecommendation'])

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -65,11 +65,10 @@ module Cb
       def self.for_company(company_did)
         my_api = Cb::Utils::Api.instance
         json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
-
         jobs = []
         if json_hash.key?('Results')
           if json_hash['Results'].key?('JobRecommendation')
-            json_hash['Results']['JobRecommendation']['Jobs'].each do |cur_job|
+            json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
               jobs << Models::Job.new(cur_job)
             end
             my_api.append_api_responses(jobs, json_hash['Results']['JobRecommendation'])

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -67,9 +67,13 @@ module Cb
         json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
         jobs = []
         if json_hash.key?('Results')
-          if json_hash['Results'].key?('JobRecommendation') && json_hash['Results']['JobRecommendation'].key?('Jobs')
-                json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
-              jobs << Models::Job.new(cur_job)
+          if json_hash['Results'].key?('JobRecommendation')
+              if json_hash['Results']['JobRecommendation'].key?('Jobs')
+                if json_hash['Results']['JobRecommendation']['Jobs'].key?('CompanyJob')
+                  json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
+                jobs << Models::Job.new(cur_job)
+                end
+              end
             end
             my_api.append_api_responses(jobs, json_hash['Results']['JobRecommendation'])
           end

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -68,10 +68,10 @@ module Cb
         jobs = []
         if json_hash.key?('Results')
           if json_hash['Results'].key?('JobRecommendation')
-              if json_hash['Results']['JobRecommendation'].key?('Jobs')
-                if json_hash['Results']['JobRecommendation']['Jobs'].key?('CompanyJob')
-                  json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
-                jobs << Models::Job.new(cur_job)
+            if json_hash['Results']['JobRecommendation'].key?('Jobs')
+              if json_hash['Results']['JobRecommendation']['Jobs'].key?('CompanyJob')
+                json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
+                  jobs << Models::Job.new(cur_job)
                 end
               end
             end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '18.5.0'
+  VERSION = '18.5.1'
 end

--- a/spec/cb/clients/recommendation_spec.rb
+++ b/spec/cb/clients/recommendation_spec.rb
@@ -82,5 +82,24 @@ module Cb
         include_context :for_user
       end
     end
+
+    shared_context :for_company do
+      it 'should get recommendations for a job using a company did' do
+        recs = Cb.recommendation.for_company('fake-did')
+
+        expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
+        expect(recs.count).to be > 0
+        expect(recs.api_error).to eq(false)
+      end
+    end
+
+    context '.for_company' do
+      before :each do
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_company))
+            .to_return(body: { Results: { JobRecommendation: { Jobs: { CompanyJob: api_job_result_collection } } } }.to_json)
+      end
+
+      include_context :for_company
+    end
   end
 end


### PR DESCRIPTION
This fixes the similar jobs for company function. If you want to reproduce this problem, simply put a breakpoint and examine 'json_hash'. You will see that this is needed.

What caused this find was using the 'employer/jobrecommendation' endpoint on branded JDP's for similar jobs.