### PR TITLE
Use chained fetch instead of nested if statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.5.2 Use fetch instead of nested if statements around company recommendations.
 * 18.5.1 Fixed the deserialization of the response from job recs for a company did.
 * 18.5.0 Adding support for Cover Letter Update.
 * 18.4.0 Adding support for Cover Letter APIs - Retrieve, List, and Delete.

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -66,21 +66,14 @@ module Cb
         my_api = Cb::Utils::Api.instance
         json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
         jobs = []
-        if json_hash.key?('Results')
-          if json_hash['Results'].key?('JobRecommendation')
-            if json_hash['Results']['JobRecommendation'].key?('Jobs')
-              if json_hash['Results']['JobRecommendation']['Jobs'].key?('CompanyJob')
-                json_hash['Results']['JobRecommendation']['Jobs']['CompanyJob'].each do |cur_job|
-                  jobs << Models::Job.new(cur_job)
-                end
-              end
-            end
-            my_api.append_api_responses(jobs, json_hash['Results']['JobRecommendation'])
-          end
-
-          my_api.append_api_responses(jobs, json_hash['Results'])
+        json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {}).fetch('CompanyJob', []).each do |cur_job|
+          jobs << Models::Job.new(cur_job)
         end
 
+        if json_hash.key?('Results')
+          my_api.append_api_responses(jobs, json_hash.fetch(['Results'], {}).fetch('JobRecommendation', {}))
+          my_api.append_api_responses(jobs, json_hash['Results'])
+        end
         my_api.append_api_responses(jobs, json_hash)
       end
 

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -70,10 +70,8 @@ module Cb
           jobs << Models::Job.new(cur_job)
         end
 
-        if json_hash.key?('Results')
-          my_api.append_api_responses(jobs, json_hash.fetch(['Results'], {}).fetch('JobRecommendation', {}))
-          my_api.append_api_responses(jobs, json_hash['Results'])
-        end
+        my_api.append_api_responses(jobs, json_hash.fetch('Results', {}).fetch('JobRecommendation', {}))
+        my_api.append_api_responses(jobs, json_hash.fetch('Results', {}))
         my_api.append_api_responses(jobs, json_hash)
       end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '18.5.1'
+  VERSION = '18.5.2'
 end


### PR DESCRIPTION
By doing this, we avoid fighting with nil checking. This does end up doing some data coercion though, so if the API was failing and returning empty for one of these keys consistently, we wouldn't see that by handling the API response this way.