### PR TITLE
fix nil jobs returned from api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.5.4 Catch nil Jobs for company recs.
 * 18.5.3 Catch nil case before even fetching.
 * 18.5.2 Use fetch instead of nested if statements around company recommendations.
 * 18.5.1 Fixed the deserialization of the response from job recs for a company did.

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -67,10 +67,12 @@ module Cb
         json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
         jobs = []
         if json_hash
-          json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {}).fetch('CompanyJob', []).each do |cur_job|
-            jobs << Models::Job.new(cur_job)
+          api_jobs = json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {})
+          if api_jobs
+            api_jobs.fetch('CompanyJob', []).each do |cur_job|
+              jobs << Models::Job.new(cur_job)
+            end
           end
-
           my_api.append_api_responses(jobs, json_hash.fetch('Results', {}).fetch('JobRecommendation', {}))
           my_api.append_api_responses(jobs, json_hash.fetch('Results', {}))
           my_api.append_api_responses(jobs, json_hash)

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '18.5.3'
+  VERSION = '18.5.4'
 end


### PR DESCRIPTION
````
[3] pry(Cb::Clients::Recommendation)> json_hash
=> {"Results"=>{"JobRecommendation"=>{"Jobs"=>nil}}}
[4] pry(Cb::Clients::Recommendation)> json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {}).fetch('CompanyJob', []).each
NoMethodError: undefined method `fetch' for nil:NilClass
from (pry):4:in `for_company'
````