### PR TITLE
Handle job response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.5.5 Turn company recs response into an array if its not.
 * 18.5.4 Catch nil Jobs for company recs.
 * 18.5.3 Catch nil case before even fetching.
 * 18.5.2 Use fetch instead of nested if statements around company recommendations.

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -69,7 +69,9 @@ module Cb
         if json_hash
           api_jobs = json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {})
           if api_jobs
-            api_jobs.fetch('CompanyJob', []).each do |cur_job|
+            company_jobs = api_jobs.fetch('CompanyJob', [])
+            company_jobs = [company_jobs] unless company_jobs.is_a?(Array)
+            company_jobs.each do |cur_job|
               jobs << Models::Job.new(cur_job)
             end
           end

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -69,8 +69,7 @@ module Cb
         if json_hash
           api_jobs = json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {})
           if api_jobs
-            company_jobs = api_jobs.fetch('CompanyJob', [])
-            company_jobs = [company_jobs] unless company_jobs.is_a?(Array)
+            company_jobs = [api_jobs.fetch('CompanyJob', [])].flatten.compact
             company_jobs.each do |cur_job|
               jobs << Models::Job.new(cur_job)
             end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '18.5.4'
+  VERSION = '18.5.5'
 end

--- a/spec/cb/clients/recommendation_spec.rb
+++ b/spec/cb/clients/recommendation_spec.rb
@@ -87,19 +87,43 @@ module Cb
       include_context :for_user
 
       context 'when the api returns one job' do
-        let(:api_job_result_collection) { Hash.new }
+        let(:api_job_result_collection) { [ Hash.new ] }
 
         include_context :for_user
       end
     end
 
     context '.for_company' do
-      before :each do
+      before do
         stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_company))
           .to_return(body: { Results: { JobRecommendation: { Jobs: { CompanyJob: api_job_result_collection } } } }.to_json)
       end
 
       it_behaves_like :for_company
+    end
+
+    context '.for_company when CompanyJob is not an array' do
+      before do
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_company))
+            .to_return(body: { Results: { JobRecommendation: { Jobs: { CompanyJob: Hash.new } } } }.to_json)
+      end
+
+      it_behaves_like :for_company
+    end
+
+    context '.for_company when CompanyJob is nil' do
+      before do
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_company))
+            .to_return(body: { Results: { JobRecommendation: { Jobs: { CompanyJob: nil } } } }.to_json)
+      end
+
+      it 'should get not have any recommendations' do
+        recs = Cb.recommendation.for_company('fake-did')
+
+        expect(recs.count).to be 0
+        expect(recs.api_error).to eq(false)
+      end
+
     end
 
     context '.for_company without results' do

--- a/spec/cb/clients/recommendation_spec.rb
+++ b/spec/cb/clients/recommendation_spec.rb
@@ -120,7 +120,7 @@ module Cb
       it 'should get not have any recommendations' do
         recs = Cb.recommendation.for_company('fake-did')
 
-        expect(recs.count).to be 0
+        expect(recs.count).to eq 0
         expect(recs.api_error).to eq(false)
       end
 


### PR DESCRIPTION
We were receiving the following error: ***TypeError: no implicit conversion of String into Integer***

Here is the json response we were getting on the ***error*** page:

````
{"Results"=>
  {"JobRecommendation"=>
    {"Jobs"=>
      {"CompanyJob"=>
        {"JobDID"=>"JHR5RK7870G6J01G6CZ", "JobLink"=>"/JobSeeker/Jobs/JobDetails.aspx?job_did=JHR5RK7870G6J01G6CZ", "JobTitle"=>"IT Technician", "Industries"=>{"string"=>"Retail"}, "Location"=>"US-GA-Atlanta", "Source"=>nil, "Date"=>"2015-10-29T08:17:27.423"}}}}}
````

We take the ````CompanyJob```` node and ````.each```` through it. Notice that this is NOT AN ARRAY so when we would loop through it, we would not pass the entire Job to  ````Models::Job````. Pages that work correctly return an array of jobs.

***Solution***: We are going to see if it is an array, and if it not, turn it into an array.

***Testing***: There is already a test that assigns a hash to the value of CompanyJob, so we are good.