### PR TITLE
Add migration id to list model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 19.1.0 Add Migration ID field to resume listing model.
 * 19.0.0 Removed job search version(s) prior to version 3.  Breaks existing consumers of the API in the following ways. JobResultsV3 renamed to JobResults.  The old JobResults path no longer works.  Users of the JobSearch API will now need to use OAuth and not Developer Keys to use the JobSearch API>
 * 18.5.6 Adding an additional field to application form
 * 18.5.5 Turn company recs response into an array if its not.

--- a/lib/cb/models/implementations/resume_listing.rb
+++ b/lib/cb/models/implementations/resume_listing.rb
@@ -16,7 +16,7 @@ module Cb
       def set_model_properties
         @title = api_response['Title']
         @external_id = api_response['ExternalID']
-        @migration_id = api_response['MigrationID']
+        @migration_id = api_response['MigrationID'] unless api_response['MigrationID'].nil?
         @host_site = api_response['HostSite']
         @modified_dt = api_response['ModifiedDT']
         @visibility = api_response['Visibility']

--- a/lib/cb/models/implementations/resume_listing.rb
+++ b/lib/cb/models/implementations/resume_listing.rb
@@ -11,11 +11,12 @@
 module Cb
   module Models
     class ResumeListing < ApiResponseModel
-      attr_accessor :title, :external_id, :host_site, :modified_dt, :visibility
+      attr_accessor :title, :external_id, :migration_id, :host_site, :modified_dt, :visibility
 
       def set_model_properties
         @title = api_response['Title']
         @external_id = api_response['ExternalID']
+        @migration_id = api_response['MigrationID']
         @host_site = api_response['HostSite']
         @modified_dt = api_response['ModifiedDT']
         @visibility = api_response['Visibility']

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '19.0.0'
+  VERSION = '19.1.0'
 end

--- a/spec/cb/models/implementations/resume_listing_spec.rb
+++ b/spec/cb/models/implementations/resume_listing_spec.rb
@@ -1,0 +1,39 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module Cb
+  module Models
+    describe ResumeListing do
+      let(:resume_listing) { Models::ResumeListing.new(resume_list_hash) }
+
+      context 'a state_hash is valid' do
+        let(:resume_list_hash) do
+          {
+            'MigrationID' => 'RC0AEA377A6D924775C',
+            'Title' => 'Software Engineer',
+            'ExternalID' => '65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975',
+            'HostSite' => 'US',
+            'ModifiedDT' => '2/16/2016 11:08:11 AM',
+            'Visibility' => 'Private'
+          }
+        end
+        it { expect(resume_listing.title).to eq('Software Engineer') }
+        it { expect(resume_listing.external_id).to eq('65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975') }
+        it { expect(resume_listing.migration_id).to eq('RC0AEA377A6D924775C') }
+        it { expect(resume_listing.host_site).to eq('US') }
+        it { expect(resume_listing.modified_dt).to eq('2/16/2016 11:08:11 AM') }
+        it { expect(resume_listing.visibility).to eq('Private') }
+      end
+    end
+  end
+end
+

--- a/spec/cb/models/implementations/resume_listing_spec.rb
+++ b/spec/cb/models/implementations/resume_listing_spec.rb
@@ -34,4 +34,3 @@ module Cb
     end
   end
 end
-

--- a/spec/cb/models/implementations/resume_listing_spec.rb
+++ b/spec/cb/models/implementations/resume_listing_spec.rb
@@ -14,25 +14,23 @@ module Cb
   module Models
     describe ResumeListing do
       let(:resume_listing) { Models::ResumeListing.new(resume_list_hash) }
-
-      context 'a state_hash is valid' do
-        let(:resume_list_hash) do
-          {
-            'MigrationID' => 'RC0AEA377A6D924775C',
-            'Title' => 'Software Engineer',
-            'ExternalID' => '65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975',
-            'HostSite' => 'US',
-            'ModifiedDT' => '2/16/2016 11:08:11 AM',
-            'Visibility' => 'Private'
-          }
-        end
-        it { expect(resume_listing.title).to eq('Software Engineer') }
-        it { expect(resume_listing.external_id).to eq('65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975') }
-        it { expect(resume_listing.migration_id).to eq('RC0AEA377A6D924775C') }
-        it { expect(resume_listing.host_site).to eq('US') }
-        it { expect(resume_listing.modified_dt).to eq('2/16/2016 11:08:11 AM') }
-        it { expect(resume_listing.visibility).to eq('Private') }
+      let(:resume_list_hash) do
+        {
+          'MigrationID' => 'RC0AEA377A6D924775C',
+          'Title' => 'Software Engineer',
+          'ExternalID' => '65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975',
+          'HostSite' => 'US',
+          'ModifiedDT' => '2/16/2016 11:08:11 AM',
+          'Visibility' => 'Private'
+        }
       end
+
+      it { expect(resume_listing.title).to eq('Software Engineer') }
+      it { expect(resume_listing.external_id).to eq('65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975') }
+      it { expect(resume_listing.migration_id).to eq('RC0AEA377A6D924775C') }
+      it { expect(resume_listing.host_site).to eq('US') }
+      it { expect(resume_listing.modified_dt).to eq('2/16/2016 11:08:11 AM') }
+      it { expect(resume_listing.visibility).to eq('Private') }
     end
   end
 end

--- a/spec/cb/models/implementations/resume_listing_spec.rb
+++ b/spec/cb/models/implementations/resume_listing_spec.rb
@@ -16,9 +16,9 @@ module Cb
       let(:resume_listing) { Models::ResumeListing.new(resume_list_hash) }
       let(:resume_list_hash) do
         {
-          'MigrationID' => 'RC0AEA377A6D924775C',
+          'MigrationID' => 'migrationID',
           'Title' => 'Software Engineer',
-          'ExternalID' => '65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975',
+          'ExternalID' => 'externalID',
           'HostSite' => 'US',
           'ModifiedDT' => '2/16/2016 11:08:11 AM',
           'Visibility' => 'Private'
@@ -26,8 +26,8 @@ module Cb
       end
 
       it { expect(resume_listing.title).to eq('Software Engineer') }
-      it { expect(resume_listing.external_id).to eq('65e7e16d36f61887e68822d2c68f8cffca46f0113afca10c330c3c27420e1975') }
-      it { expect(resume_listing.migration_id).to eq('RC0AEA377A6D924775C') }
+      it { expect(resume_listing.external_id).to eq('externalID') }
+      it { expect(resume_listing.migration_id).to eq('migrationID') }
       it { expect(resume_listing.host_site).to eq('US') }
       it { expect(resume_listing.modified_dt).to eq('2/16/2016 11:08:11 AM') }
       it { expect(resume_listing.visibility).to eq('Private') }

--- a/spec/cb/models/implementations/resume_listing_spec.rb
+++ b/spec/cb/models/implementations/resume_listing_spec.rb
@@ -31,6 +31,20 @@ module Cb
       it { expect(resume_listing.host_site).to eq('US') }
       it { expect(resume_listing.modified_dt).to eq('2/16/2016 11:08:11 AM') }
       it { expect(resume_listing.visibility).to eq('Private') }
+
+      context 'listing does not contain a migration ID' do
+        let(:resume_list_hash) do
+          {
+              'Title' => 'Software Engineer',
+              'ExternalID' => 'externalID',
+              'HostSite' => 'US',
+              'ModifiedDT' => '2/16/2016 11:08:11 AM',
+              'Visibility' => 'Private'
+          }
+        end
+
+        it { expect(resume_listing.migration_id.nil?).to be(true) }
+      end
     end
   end
 end


### PR DESCRIPTION
To use the new Resume API in c-m, we need the current get list API to return the migration ID of the requested resume so that GRRP can use the correct ID when calling retrieve since, initially, it will not use the new get list API. The change to send the migration ID back has been made on the matrix and is flag wrapped

If the migration ID exists, it means the resume has been migrated to the new service and that ID should be used when requesting the resume from the new service. 

If no migration ID is present, the external id should be used. That will trigger the new service to pull the resume over from the matrix.