### PR TITLE
Dont Merge: Refactoring of the old clients, add new coverletter endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
-* 20.0.0 Refactoring of the clients,
+* 20.0.0 Refactoring of the clients.  Breaking changes to AnonSavedSearch, EmployeeTypes, SavedSearch
 * 19.1.1 No functional differences, some code cleanup
 * 19.1.0 Add Migration ID field to resume listing model.
 * 19.0.0 Removed job search version(s) prior to version 3.  Breaks existing consumers of the API in the following ways. JobResultsV3 renamed to JobResults.  The old JobResults path no longer works.  Users of the JobSearch API will now need to use OAuth and not Developer Keys to use the JobSearch API>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 20.0.0 Refactoring of the clients,
 * 19.1.1 No functional differences, some code cleanup
 * 19.1.0 Add Migration ID field to resume listing model.
 * 19.0.0 Removed job search version(s) prior to version 3.  Breaks existing consumers of the API in the following ways. JobResultsV3 renamed to JobResults.  The old JobResults path no longer works.  Users of the JobSearch API will now need to use OAuth and not Developer Keys to use the JobSearch API>

--- a/lib/cb/clients/anon_saved_search.rb
+++ b/lib/cb/clients/anon_saved_search.rb
@@ -8,16 +8,17 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
 module Cb
   module Clients
-    class AnonSavedSearch
-      def create(*args)
+    class AnonSavedSearch < Base
+      def self.create(*args)
         body = new_model(*args).create_anon_to_xml
         json = cb_client.cb_post(create_uri, body: body)
         Responses::AnonymousSavedSearch::Create.new(json)
       end
 
-      def delete(*args)
+      def self.delete(*args)
         body = new_model(*args).delete_anon_to_xml
         json = cb_client.cb_post(delete_uri, body: body)
         Responses::AnonymousSavedSearch::Delete.new(json)
@@ -25,25 +26,21 @@ module Cb
 
       private
 
-      def new_model(*args)
+      def self.new_model(*args)
         return args.first if args.respond_to?(:[]) && args.first.is_a?(Models::SavedSearch)
         Models::SavedSearch.new(extract_args(*args))
       end
 
-      def extract_args(*args)
+      def self.extract_args(*args)
         args.is_a?(Array) && args.count == 1 ? args[0] : args
       end
 
-      def create_uri
+      def self.create_uri
         Cb.configuration.uri_anon_saved_search_create
       end
 
-      def delete_uri
+      def self.delete_uri
         Cb.configuration.uri_anon_saved_search_delete
-      end
-
-      def cb_client
-        @cb_client ||= Cb::Utils::Api.instance
       end
     end
   end

--- a/lib/cb/clients/application.rb
+++ b/lib/cb/clients/application.rb
@@ -8,9 +8,10 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
 module Cb
   module Clients
-    class Application
+    class Application < Base
       class << self
         def get(criteria)
           response cb_call(:get, criteria, Cb.configuration.host_site)
@@ -26,7 +27,7 @@ module Cb
 
         def form(job_id)
           url = Cb.configuration.uri_application_form.sub(':did', job_id)
-          response_hash = api_client.cb_get(url, headers: headers(Cb.configuration.host_site))
+          response_hash = cb_client.cb_get(url, headers: headers(Cb.configuration.host_site))
           Responses::ApplicationForm.new response_hash
         end
 
@@ -40,7 +41,7 @@ module Cb
           end
 
           uri = uri(criteria)
-          api_client.method(:"cb_#{http_method}").call(uri, options)
+          cb_client.method(:"cb_#{http_method}").call(uri, options)
         end
 
         def response(response_hash)
@@ -58,10 +59,6 @@ module Cb
             'HostSite' => host_site,
             'Content-Type' => 'application/json'
           }
-        end
-
-        def api_client
-          Cb::Utils::Api.instance
         end
       end
     end

--- a/lib/cb/clients/application_external.rb
+++ b/lib/cb/clients/application_external.rb
@@ -9,15 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'json'
-
+require_relative 'base'
 module Cb
   module Clients
-    class ApplicationExternal
+    class ApplicationExternal < Base
       def self.submit_app(app)
         fail Cb::IncomingParamIsWrongTypeException unless app.is_a?(Cb::Models::ApplicationExternal)
 
-        my_api = Cb::Utils::Api.instance
-        xml_hash = my_api.cb_post(Cb.configuration.uri_application_external, body: app.to_xml)
+        xml_hash = cb_client.cb_post(Cb.configuration.uri_application_external, body: app.to_xml)
 
         if xml_hash.key? 'ApplyUrl'
           app.apply_url = xml_hash['ApplyUrl']
@@ -25,7 +24,7 @@ module Cb
           app.apply_url = ''
         end
 
-        my_api.append_api_responses(app, xml_hash)
+        cb_client.append_api_responses(app, xml_hash)
       end
     end
   end

--- a/lib/cb/clients/base.rb
+++ b/lib/cb/clients/base.rb
@@ -8,24 +8,11 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-require 'json'
-require_relative 'base'
 module Cb
   module Clients
-    class Job < Base
-      class << self
-        def find_by_criteria(criteria)
-          query = cb_client.class.criteria_to_hash(criteria)
-          json_response = cb_client.cb_get(Cb.configuration.uri_job_find, query: query)
-          Responses::Job::Singular.new(json_response)
-        end
-
-        def find_by_did(did)
-          criteria = Cb::Criteria::Job::Details.new
-          criteria.did = did
-          criteria.show_custom_values = true
-          find_by_criteria(criteria)
-        end
+    class Base
+      def self.cb_client
+        @cb_client ||= Cb::Utils::Api.instance
       end
     end
   end

--- a/lib/cb/clients/category.rb
+++ b/lib/cb/clients/category.rb
@@ -9,13 +9,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'json'
-
+require_relative 'base'
 module Cb
   module Clients
-    class Category
+    class Category < Base
       def self.search
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get(Cb.configuration.uri_job_category_search)
+        json_hash = cb_client.cb_get(Cb.configuration.uri_job_category_search)
         categoryList = []
 
         if json_hash.key?('ResponseCategories')
@@ -25,15 +24,14 @@ module Cb
             end
           end
 
-          my_api.append_api_responses(categoryList, json_hash['ResponseCategories'])
+          cb_client.append_api_responses(categoryList, json_hash['ResponseCategories'])
         end
 
-        my_api.append_api_responses(categoryList, json_hash)
+        cb_client.append_api_responses(categoryList, json_hash)
       end
 
       def self.search_by_host_site(host_site)
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get(Cb.configuration.uri_job_category_search, query: { CountryCode: host_site })
+        json_hash = cb_client.cb_get(Cb.configuration.uri_job_category_search, query: { CountryCode: host_site })
         categoryList = []
 
         if json_hash.key?('ResponseCategories')
@@ -47,10 +45,10 @@ module Cb
             end
           end
 
-          my_api.append_api_responses(categoryList, json_hash['ResponseCategories'])
+          cb_client.append_api_responses(categoryList, json_hash['ResponseCategories'])
         end
 
-        my_api.append_api_responses(categoryList, json_hash)
+        cb_client.append_api_responses(categoryList, json_hash)
       end
     end
   end

--- a/lib/cb/clients/company.rb
+++ b/lib/cb/clients/company.rb
@@ -9,22 +9,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'json'
-
+require_relative 'base'
 module Cb
   module Clients
-    class Company
+    class Company < Base
       def self.find_by_did(did)
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get(Cb.configuration.uri_company_find, query: { CompanyDID: did, hostsite: Cb.configuration.host_site })
+        json_hash = cb_client.cb_get(Cb.configuration.uri_company_find,
+                                     query: { CompanyDID: did, hostsite: Cb.configuration.host_site })
 
         if json_hash.key?('Results')
           if json_hash['Results'].key?('CompanyProfileDetail')
             company = Models::Company.new(json_hash['Results']['CompanyProfileDetail'])
           end
-          my_api.append_api_responses(company, json_hash['Results'])
+          cb_client.append_api_responses(company, json_hash['Results'])
         end
 
-        my_api.append_api_responses(company, json_hash)
+        cb_client.append_api_responses(company, json_hash)
       end
 
       def self.find_for(obj)

--- a/lib/cb/clients/cover_letters.rb
+++ b/lib/cb/clients/cover_letters.rb
@@ -12,20 +12,21 @@ require_relative 'base'
 module Cb
   module Clients
     class CoverLetters < Base
-      def self.get(*args)
-        json = cb_client.cb_get(Cb.configuration.uri_cover_letters,
+      def self.get(args={})
+        uri = Cb.configuration.uri_cover_letters
+        uri += "/#{ args[:id] }" if args[:id]
+        json = cb_client.cb_get(uri,
                                 headers: CoverLetters.headers(args))
         JSON.parse(json, symbolize_names: true)
       end
 
-      def self.create(*args)
-        json = cb_client.cb_put(Cb.configuration.uri_cover_letters,
-                                body: CoverLetter.body(args),
-                                headers: CoverLetters.headers(args))
-        JSON.parse(json, symbolize_names: true)
+      def self.create(args={})
+        cb_client.cb_put(Cb.configuration.uri_cover_letters,
+                         body: body(args),
+                         headers: headers(args))
       end
 
-      def self.delete(*args)
+      def self.delete(args={})
         uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
         json = cb_client.cb_delete(uri,
                                    body: CoverLetter.body(args),
@@ -33,7 +34,7 @@ module Cb
         JSON.parse(json, symbolize_names: true)
       end
 
-      def self.update(*args)
+      def self.update(args={})
         uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
         json = cb_client.cb_delete(uri,
                                    body: CoverLetter.body(args),
@@ -42,14 +43,14 @@ module Cb
       end
 
       private
-      def headers(*args)
+      def self.headers(args)
         {
-            'Accept' => 'application/json;',
+            'Accept' => 'application/json',
             'Authorization' => "Bearer #{ args[:oauth_token] }"
         }
       end
 
-      def body(*args)
+      def self.body(args)
         body = Hash.new
         body[:id] = args[:id] if args[:id]
         body[:text] = args[:text] if args[:text]

--- a/lib/cb/clients/cover_letters.rb
+++ b/lib/cb/clients/cover_letters.rb
@@ -38,7 +38,8 @@ module Cb
       def self.headers(args)
         {
             'Accept' => 'application/json',
-            'Authorization' => "Bearer #{ args[:oauth_token] }"
+            'Authorization' => "Bearer #{ args[:oauth_token] }",
+            'Content-Type' => 'application/json'
         }
       end
 

--- a/lib/cb/clients/cover_letters.rb
+++ b/lib/cb/clients/cover_letters.rb
@@ -15,9 +15,7 @@ module Cb
       def self.get(args={})
         uri = Cb.configuration.uri_cover_letters
         uri += "/#{ args[:id] }" if args[:id]
-        json = cb_client.cb_get(uri,
-                                headers: CoverLetters.headers(args))
-        JSON.parse(json, symbolize_names: true)
+        cb_client.cb_get(uri, headers: headers(args))
       end
 
       def self.create(args={})
@@ -28,10 +26,9 @@ module Cb
 
       def self.delete(args={})
         uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
-        json = cb_client.cb_delete(uri,
-                                   body: CoverLetter.body(args),
-                                   headers: CoverLetters.headers(args))
-        JSON.parse(json, symbolize_names: true)
+        cb_client.cb_delete(uri,
+                            body: CoverLetter.body(args),
+                            headers: CoverLetters.headers(args))
       end
 
       def self.update(args={})

--- a/lib/cb/clients/cover_letters.rb
+++ b/lib/cb/clients/cover_letters.rb
@@ -1,0 +1,61 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
+module Cb
+  module Clients
+    class CoverLetters < Base
+      def self.get(*args)
+        json = cb_client.cb_get(Cb.configuration.uri_cover_letters,
+                                headers: CoverLetters.headers(args))
+        JSON.parse(json, symbolize_names: true)
+      end
+
+      def self.create(*args)
+        json = cb_client.cb_put(Cb.configuration.uri_cover_letters,
+                                body: CoverLetter.body(args),
+                                headers: CoverLetters.headers(args))
+        JSON.parse(json, symbolize_names: true)
+      end
+
+      def self.delete(*args)
+        uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
+        json = cb_client.cb_delete(uri,
+                                   body: CoverLetter.body(args),
+                                   headers: CoverLetters.headers(args))
+        JSON.parse(json, symbolize_names: true)
+      end
+
+      def self.update(*args)
+        uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
+        json = cb_client.cb_delete(uri,
+                                   body: CoverLetter.body(args),
+                                   headers: CoverLetters.headers(args))
+        JSON.parse(json, symbolize_names: true)
+      end
+
+      private
+      def headers(*args)
+        {
+            'Accept' => 'application/json;',
+            'Authorization' => "Bearer #{ args[:oauth_token] }"
+        }
+      end
+
+      def body(*args)
+        body = Hash.new
+        body[:id] = args[:id] if args[:id]
+        body[:text] = args[:text] if args[:text]
+        body[:name] = args[:name] if args[:name]
+        body.to_json
+      end
+    end
+  end
+end

--- a/lib/cb/clients/cover_letters.rb
+++ b/lib/cb/clients/cover_letters.rb
@@ -26,17 +26,12 @@ module Cb
 
       def self.delete(args={})
         uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
-        cb_client.cb_delete(uri,
-                            body: CoverLetter.body(args),
-                            headers: CoverLetters.headers(args))
+        cb_client.cb_delete(uri, body: body(args), headers: headers(args))
       end
 
       def self.update(args={})
         uri = "#{ Cb.configuration.uri_cover_letters }/#{ args[:id] }"
-        json = cb_client.cb_delete(uri,
-                                   body: CoverLetter.body(args),
-                                   headers: CoverLetters.headers(args))
-        JSON.parse(json, symbolize_names: true)
+        cb_client.cb_post(uri, body: body(args), headers: headers(args))
       end
 
       private

--- a/lib/cb/clients/education.rb
+++ b/lib/cb/clients/education.rb
@@ -9,14 +9,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'json'
-
+require_relative 'base'
 module Cb
   module Clients
-    class Education
+    class Education < Base
       def self.get_for(country)
         Cb::Utils::Country.is_valid? country ? country : 'US'
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get(Cb.configuration.uri_education_code, query: { countrycode: country })
+        json_hash = cb_client.cb_get(Cb.configuration.uri_education_code, query: { countrycode: country })
 
         codes = []
         if json_hash.key?('ResponseEducationCodes')
@@ -26,10 +25,10 @@ module Cb
               codes << Cb::Models::Education.new(education)
             end
           end
-          my_api.append_api_responses(codes, json_hash['ResponseEducationCodes'])
+          cb_client.append_api_responses(codes, json_hash['ResponseEducationCodes'])
         end
 
-        my_api.append_api_responses(codes, json_hash)
+        cb_client.append_api_responses(codes, json_hash)
       end
     end
   end

--- a/lib/cb/clients/employee_types.rb
+++ b/lib/cb/clients/employee_types.rb
@@ -8,30 +8,27 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
 module Cb
   module Clients
-    class EmployeeTypes
-      def search
+    class EmployeeTypes < Base
+      def self.search
         json = cb_client.cb_get(endpoint)
         new_response_object(json)
       end
 
-      def search_by_hostsite(host_site)
+      def self.search_by_hostsite(host_site)
         json = cb_client.cb_get(endpoint, query: { CountryCode: host_site })
         new_response_object(json)
       end
 
       private
 
-      def cb_client
-        @client ||= Cb::Utils::Api.instance
-      end
-
-      def endpoint
+      def self.endpoint
         Cb.configuration.uri_employee_types
       end
 
-      def new_response_object(json_response)
+      def self.new_response_object(json_response)
         Responses::EmployeeTypes::Search.new(json_response)
       end
     end

--- a/lib/cb/clients/industry.rb
+++ b/lib/cb/clients/industry.rb
@@ -9,21 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'json'
-
+require_relative 'base'
 module Cb
   module Clients
-    class Industry
-      class << self
-        def search
-          response = api_client.cb_get(Cb.configuration.uri_job_industry_search, query: { CountryCode: Cb.configuration.host_site })
-          Cb::Responses::Industry::Search.new(response)
-        end
-
-        private
-
-        def api_client
-          @api ||= Cb::Utils::Api.instance
-        end
+    class Industry < Base
+      def search
+        response = cb_client.cb_get(Cb.configuration.uri_job_industry_search,
+                                    query: { CountryCode: Cb.configuration.host_site })
+        Cb::Responses::Industry::Search.new(response)
       end
     end
   end

--- a/lib/cb/clients/industry.rb
+++ b/lib/cb/clients/industry.rb
@@ -13,7 +13,7 @@ require_relative 'base'
 module Cb
   module Clients
     class Industry < Base
-      def search
+      def self.search
         response = cb_client.cb_get(Cb.configuration.uri_job_industry_search,
                                     query: { CountryCode: Cb.configuration.host_site })
         Cb::Responses::Industry::Search.new(response)

--- a/lib/cb/clients/job_branding.rb
+++ b/lib/cb/clients/job_branding.rb
@@ -10,17 +10,16 @@
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
   module Clients
-    class JobBranding
+    class JobBranding < Base
       def self.find_by_id(id)
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get Cb.configuration.uri_job_branding, query: { id: id }
+        json_hash = cb_client.cb_get Cb.configuration.uri_job_branding, query: { id: id }
 
         if json_hash.key? 'Branding'
           branding = Models::JobBranding.new json_hash['Branding']
-          my_api.append_api_responses(branding, json_hash['Branding'])
+          cb_client.append_api_responses(branding, json_hash['Branding'])
         end
 
-        my_api.append_api_responses(branding, json_hash)
+        cb_client.append_api_responses(branding, json_hash)
       end
     end
   end

--- a/lib/cb/clients/job_branding.rb
+++ b/lib/cb/clients/job_branding.rb
@@ -8,6 +8,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
 module Cb
   module Clients
     class JobBranding < Base

--- a/lib/cb/clients/recommendation.rb
+++ b/lib/cb/clients/recommendation.rb
@@ -9,15 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 require 'json'
-
+require_relative 'base'
 module Cb
   module Clients
-    class Recommendation
+    class Recommendation < Base
       def self.for_job(*args)
-        my_api = Cb::Utils::Api.instance
         hash = normalize_args(args)
         hash = set_hash_defaults(hash)
-        json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_job,
+        json_hash = cb_client.cb_get(Cb.configuration.uri_recommendation_for_job,
                                   query: hash)
 
         jobs = []
@@ -28,20 +27,19 @@ module Cb
 
             jobs = create_jobs json_hash, 'Job'
 
-            my_api.append_api_responses(jobs, json_hash['ResponseRecommendJob']['Request'])
+            cb_client.append_api_responses(jobs, json_hash['ResponseRecommendJob']['Request'])
           end
 
-          my_api.append_api_responses(jobs, json_hash['ResponseRecommendJob'])
+          cb_client.append_api_responses(jobs, json_hash['ResponseRecommendJob'])
         end
 
-        my_api.append_api_responses(jobs, json_hash)
+        cb_client.append_api_responses(jobs, json_hash)
       end
 
       def self.for_user(*args)
-        my_api = Cb::Utils::Api.instance
         hash = normalize_args(args)
         hash = set_hash_defaults(hash)
-        json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_user,
+        json_hash = cb_client.cb_get(Cb.configuration.uri_recommendation_for_user,
                                   query: hash)
 
         jobs = []
@@ -53,18 +51,17 @@ module Cb
 
             jobs = create_jobs json_hash, 'User'
 
-            my_api.append_api_responses(jobs, json_hash['ResponseRecommendUser']['Request'])
+            cb_client.append_api_responses(jobs, json_hash['ResponseRecommendUser']['Request'])
           end
 
-          my_api.append_api_responses(jobs, json_hash['ResponseRecommendUser'])
+          cb_client.append_api_responses(jobs, json_hash['ResponseRecommendUser'])
         end
 
-        my_api.append_api_responses(jobs, json_hash)
+        cb_client.append_api_responses(jobs, json_hash)
       end
 
       def self.for_company(company_did)
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
+        json_hash = cb_client.cb_get(Cb.configuration.uri_recommendation_for_company, query: { CompanyDID: company_did })
         jobs = []
         if json_hash
           api_jobs = json_hash.fetch('Results', {}).fetch('JobRecommendation', {}).fetch('Jobs', {})
@@ -74,9 +71,9 @@ module Cb
               jobs << Models::Job.new(cur_job)
             end
           end
-          my_api.append_api_responses(jobs, json_hash.fetch('Results', {}).fetch('JobRecommendation', {}))
-          my_api.append_api_responses(jobs, json_hash.fetch('Results', {}))
-          my_api.append_api_responses(jobs, json_hash)
+          cb_client.append_api_responses(jobs, json_hash.fetch('Results', {}).fetch('JobRecommendation', {}))
+          cb_client.append_api_responses(jobs, json_hash.fetch('Results', {}))
+          cb_client.append_api_responses(jobs, json_hash)
         end
       end
 

--- a/lib/cb/clients/saved_search.rb
+++ b/lib/cb/clients/saved_search.rb
@@ -8,22 +8,23 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
 module Cb
   module Clients
-    class SavedSearch
-      def create(saved_search)
+    class SavedSearch < Base
+      def self.create(saved_search)
         body = saved_search.create_to_xml
         json = cb_client.cb_post(Cb.configuration.uri_saved_search_create, body: body)
         singular_model_response(json, saved_search.external_user_id)
       end
 
-      def update(saved_search)
+      def self.update(saved_search)
         body = saved_search.update_to_json
         json = cb_client.cb_put(Cb.configuration.uri_saved_search_update, body: body, headers: update_headers(saved_search.host_site))
         Responses::SavedSearch::Update.new(json)
       end
 
-      def delete(hash)
+      def self.delete(hash)
         uri = replace_uri_field(Cb.configuration.uri_saved_search_delete, ':did', hash[:did])
         json = cb_client.cb_delete(
           uri,
@@ -33,14 +34,14 @@ module Cb
         Responses::SavedSearch::Delete.new(json)
       end
 
-      def retrieve(oauth_token, external_id)
+      def self.retrieve(oauth_token, external_id)
         query = retrieve_query(oauth_token)
         uri = replace_uri_field(Cb.configuration.uri_saved_search_retrieve, ':did', external_id)
         json = cb_client.cb_get(uri, query: query)
         Responses::SavedSearch::Retrieve.new(json)
       end
 
-      def list(oauth_token, hostsite)
+      def self.list(oauth_token, hostsite)
         query = list_query(oauth_token, hostsite)
         json = cb_client.cb_get(Cb.configuration.uri_saved_search_list, query: query)
         Responses::SavedSearch::List.new(json)
@@ -48,7 +49,7 @@ module Cb
 
       private
 
-      def update_headers(host_site)
+      def self.update_headers(host_site)
         {
           'developerkey' => Cb.configuration.dev_key,
           'Content-Type' => 'application/json',
@@ -56,18 +57,14 @@ module Cb
         }
       end
 
-      def cb_client
-        @cb_client ||= Cb::Utils::Api.instance
-      end
-
-      def retrieve_query(oauth_token)
+      def self.retrieve_query(oauth_token)
         {
           developerkey: Cb.configuration.dev_key,
           useroauthtoken: oauth_token
         }
       end
 
-      def list_query(oauth_token, hostsite)
+      def self.list_query(oauth_token, hostsite)
         {
           developerkey: Cb.configuration.dev_key,
           useroauthtoken: oauth_token,
@@ -75,13 +72,13 @@ module Cb
         }
       end
 
-      def singular_model_response(json_hash, external_user_id = nil, external_id = nil)
+      def self.singular_model_response(json_hash, external_user_id = nil, external_id = nil)
         json_hash['ExternalUserID'] = external_user_id unless external_user_id.nil?
         json_hash['ExternalID'] = external_id unless external_id.nil?
         Responses::SavedSearch::Singular.new(json_hash)
       end
 
-      def replace_uri_field(uri_string, field, replacement)
+      def self.replace_uri_field(uri_string, field, replacement)
         uri_string.gsub(field, replacement)
       end
     end

--- a/lib/cb/clients/talent_network.rb
+++ b/lib/cb/clients/talent_network.rb
@@ -8,51 +8,47 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
 module Cb
   module Clients
-    class TalentNetwork
+    class TalentNetwork < Base
       def self.join_form_questions(tndid)
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get("#{Cb.configuration.uri_tn_join_questions}/#{tndid}/json")
+        json_hash = cb_client.cb_get("#{Cb.configuration.uri_tn_join_questions}/#{tndid}/json")
         tn_questions_collection = Models::TalentNetwork.new(json_hash)
-        my_api.append_api_responses(tn_questions_collection, json_hash)
+        cb_client.append_api_responses(tn_questions_collection, json_hash)
       end
 
       def self.join_form_branding(tndid)
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get("#{Cb.configuration.uri_tn_join_form_branding}/#{tndid}/json")
+        json_hash = cb_client.cb_get("#{Cb.configuration.uri_tn_join_form_branding}/#{tndid}/json")
 
         if json_hash.key? 'Branding'
           tn_join_form_branding = Models::TalentNetwork::JoinFormBranding.new(json_hash['Branding'])
         end
 
-        my_api.append_api_responses(tn_join_form_branding, json_hash)
+        cb_client.append_api_responses(tn_join_form_branding, json_hash)
       end
 
       def self.join_form_geography(tnlanguage = 'USEnglish')
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get("#{Cb.configuration.uri_tn_join_form_geo}", query: { TNLanguage: "#{tnlanguage}" })
+        json_hash = cb_client.cb_get("#{Cb.configuration.uri_tn_join_form_geo}", query: { TNLanguage: "#{tnlanguage}" })
         geo_dropdown = Models::TalentNetwork::JoinFormGeo.new(json_hash)
-        my_api.append_api_responses(geo_dropdown, json_hash)
+        cb_client.append_api_responses(geo_dropdown, json_hash)
       end
 
       def self.member_create(args = {})
-        my_api = Cb::Utils::Api.instance
         tn_member = Models::TalentNetwork::Member.new(args)
-        json_hash = my_api.cb_post("#{Cb.configuration.uri_tn_member_create}/json", body: tn_member.to_xml)
-        my_api.append_api_responses(json_hash, json_hash)
+        json_hash = cb_client.cb_post("#{Cb.configuration.uri_tn_member_create}/json", body: tn_member.to_xml)
+        cb_client.append_api_responses(json_hash, json_hash)
       end
 
       def self.tn_job_information(job_did, join_form_intercept = 'true')
-        my_api = Cb::Utils::Api.instance
-        json_hash = my_api.cb_get("#{Cb.configuration.uri_tn_job_info}/#{job_did}/json",
+        json_hash = cb_client.cb_get("#{Cb.configuration.uri_tn_job_info}/#{job_did}/json",
                                   query: {RequestJoinFormIntercept: join_form_intercept } )
 
         if json_hash.key? 'Response'
           tn_job_info = Models::TalentNetwork::JobInfo.new(json_hash['Response'])
         end
 
-        my_api.append_api_responses(tn_job_info, json_hash)
+        cb_client.append_api_responses(tn_job_info, json_hash)
       end
     end
   end

--- a/lib/cb/clients/user.rb
+++ b/lib/cb/clients/user.rb
@@ -28,7 +28,7 @@ module Cb
 
         def retrieve(external_id, _test_mode = false)
           cb_client = Cb::Utils::Api.instance
-          json_hash = my_api.cb_post Cb.configuration.uri_user_retrieve, body: build_retrieve_request(external_id, true)
+          json_hash = cb_client.cb_post Cb.configuration.uri_user_retrieve, body: build_retrieve_request(external_id, true)
           if json_hash.key? 'ResponseUserInfo'
             if json_hash['ResponseUserInfo'].key? 'UserInfo'
               user = Models::User.new json_hash['ResponseUserInfo']['UserInfo']

--- a/lib/cb/clients/user.rb
+++ b/lib/cb/clients/user.rb
@@ -12,45 +12,43 @@ require 'json'
 
 module Cb
   module Clients
-    class User
+    class User < Base
       class << self
         def check_existing(email, password)
           xml = build_check_existing_request(email, password)
-          response = api_client.cb_post(Cb.configuration.uri_user_check_existing, body: xml)
+          response = cb_client.cb_post(Cb.configuration.uri_user_check_existing, body: xml)
           Cb::Responses::User::CheckExisting.new(response)
         end
 
         def temporary_password(external_id)
           query = { 'ExternalID' => external_id }
-          response = api_client.cb_get(Cb.configuration.uri_user_temp_password, query: query)
+          response = cb_client.cb_get(Cb.configuration.uri_user_temp_password, query: query)
           Cb::Responses::User::TemporaryPassword.new(response)
         end
 
         def retrieve(external_id, _test_mode = false)
-          my_api = Cb::Utils::Api.instance
+          cb_client = Cb::Utils::Api.instance
           json_hash = my_api.cb_post Cb.configuration.uri_user_retrieve, body: build_retrieve_request(external_id, true)
           if json_hash.key? 'ResponseUserInfo'
             if json_hash['ResponseUserInfo'].key? 'UserInfo'
               user = Models::User.new json_hash['ResponseUserInfo']['UserInfo']
             end
-            my_api.append_api_responses user, json_hash['ResponseUserInfo']
+            cb_client.append_api_responses user, json_hash['ResponseUserInfo']
           end
 
-          my_api.append_api_responses user, json_hash
+          cb_client.append_api_responses user, json_hash
         end
 
         def change_password(user_info)
-          my_api = Cb::Utils::Api.instance
           uri = Cb.configuration.uri_user_change_password
-          response = my_api.cb_post(uri, body: user_info.to_xml)
+          response = cb_client.cb_post(uri, body: user_info.to_xml)
 
           Cb::Responses::User::ChangePassword.new(response) if response.key?('ResponseUserChangePW')
         end
 
         def delete(delete_criteria)
-          my_api = Cb::Utils::Api.instance
           uri = Cb.configuration.uri_user_delete
-          response = my_api.cb_post(uri, body: delete_criteria.to_xml)
+          response = cb_client.cb_post(uri, body: delete_criteria.to_xml)
 
           Cb::Responses::User::Delete.new(response) if response.key?('ResponseUserDelete')
         end
@@ -88,10 +86,6 @@ module Cb
               <NewPassword>#{new_password}</NewPassword>
             </Request>
           eos
-        end
-
-        def api_client
-          Cb::Utils::Api.instance
         end
       end
     end

--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -63,6 +63,7 @@ module Cb
       @uri_application_form ||= '/cbapi/job/:did/applicationform'
       @uri_company_find ||= '/Employer/CompanyDetails'
       @uri_countries ||= '/consumer/datalist/countries'
+      @uri_cover_letters ||= '/consumer/coverletters'
       @uri_cover_letter_list ||= '/v1/coverletter/list'
       @uri_cover_letter_retrieve ||= '/coverletter/retrieve'
       @uri_cover_letter_update ||= '/coverletter/edit'

--- a/lib/cb/convenience.rb
+++ b/lib/cb/convenience.rb
@@ -20,7 +20,7 @@ module Cb
       end
 
       def job_details_criteria
-        Cb::Criteria::Job::Details
+        Cb::Criteria::Job::Details.new
       end
 
       def category

--- a/lib/cb/convenience.rb
+++ b/lib/cb/convenience.rb
@@ -27,6 +27,10 @@ module Cb
         Cb::Clients::Category
       end
 
+      def cover_letters
+        Cb::Clients::CoverLetters
+      end
+
       def industry
         Cb::Clients::Industry
       end

--- a/lib/cb/convenience.rb
+++ b/lib/cb/convenience.rb
@@ -20,7 +20,7 @@ module Cb
       end
 
       def job_details_criteria
-        Cb::Criteria::Job::Details.new
+        Cb::Criteria::Job::Details
       end
 
       def category

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -73,6 +73,10 @@ module Cb
       end
 
       def append_api_responses(obj, resp)
+        #As of ruby 2.2 nil is frozen so stop monkey patching it please -jyeary
+        if obj.nil? && obj.frozen?
+          obj = Cb::Utils::NilResponse.new
+        end
         meta_class = ensure_non_nil_metavalues(obj)
 
         resp.each do |api_key, api_value|
@@ -92,7 +96,6 @@ module Cb
             meta_class.instance_variable_set(:"@#{meta_name}", api_value)
           end
         end
-
         obj.class.send(:attr_reader, 'api_error')
         obj.instance_variable_set(:@api_error, @api_error)
 

--- a/lib/cb/utils/nil_response.rb
+++ b/lib/cb/utils/nil_response.rb
@@ -8,24 +8,15 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-require 'json'
-require_relative 'base'
-module Cb
-  module Clients
-    class Job < Base
-      class << self
-        def find_by_criteria(criteria)
-          query = cb_client.class.criteria_to_hash(criteria)
-          json_response = cb_client.cb_get(Cb.configuration.uri_job_find, query: query)
-          Responses::Job::Singular.new(json_response)
-        end
+require 'httparty'
+require 'observer'
 
-        def find_by_did(did)
-          criteria = Cb::Criteria::Job::Details.new
-          criteria.did = did
-          criteria.show_custom_values = true
-          find_by_criteria(criteria)
-        end
+module Cb
+  module Utils
+    class NilResponse
+      def initialize ;end
+      def nil?
+        true
       end
     end
   end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '19.1.1'
+  VERSION = '20.0.0'
 end

--- a/spec/cb/clients/anon_saved_search_spec.rb
+++ b/spec/cb/clients/anon_saved_search_spec.rb
@@ -11,7 +11,7 @@
 require 'spec_helper'
 
 module Cb
-  describe Cb::Clients::AnonSavedSearch.new do
+  describe Cb::Clients::AnonSavedSearch do
     before :each do
       @args = {
         'EmailAddress' => 'test@test.com',

--- a/spec/cb/clients/anon_saved_search_spec.rb
+++ b/spec/cb/clients/anon_saved_search_spec.rb
@@ -49,11 +49,11 @@ module Cb
           end
 
           it 'the Cb module convenience method' do
-            assert_no_error_on_model { Cb.anon_saved_search.new.create @args }
+            assert_no_error_on_model { Cb.anon_saved_search.create @args }
           end
 
           it 'the anonymous saved search api client directly' do
-            assert_no_error_on_model { Cb::Clients::AnonSavedSearch.new.create @args }
+            assert_no_error_on_model { Cb::Clients::AnonSavedSearch.create @args }
           end
         end
       end
@@ -77,7 +77,7 @@ module Cb
         end
 
         it 'should successfully delete an anonymous saved search' do
-          response = Cb.anon_saved_search.new.delete @args
+          response = Cb.anon_saved_search.delete @args
           expect(response.model.status).to eq 'Success'
         end
       end

--- a/spec/cb/clients/application_external_spec.rb
+++ b/spec/cb/clients/application_external_spec.rb
@@ -29,7 +29,10 @@ module Cb
       end
 
       context 'when everything is working correctly' do
-        let(:external_app) { Cb::Models::ApplicationExternal.new(job_did: 'did', email: 'bogus@bogus.org', ipath: 'bogus', site_id: 'bogus') }
+        let(:external_app) { Cb::Models::ApplicationExternal.new(job_did: 'did',
+                                                                 email: 'bogus@bogus.org',
+                                                                 ipath: 'bogus',
+                                                                 site_id: 'bogus') }
 
         it 'the same application object is returned that is supplied for input' do
           stub_api_call_to_return({})
@@ -57,20 +60,9 @@ module Cb
         end
 
         context 'when posting to the API' do
-          before(:each) do
-            @mock_api = double(Cb::Utils::Api)
-            allow(@mock_api).to receive(:cb_post)
-            allow(@mock_api).to receive(:append_api_responses)
-            allow(Cb::Utils::Api).to receive(:new).and_return @mock_api
-          end
-
-          it 'converts the application to xml' do
-            expect(@mock_api).to receive(:cb_post).with(kind_of(String), body: external_app.to_xml).and_return({})
-            submit_app(external_app)
-          end
-
-          it 'posts to the application external API endpoint' do
-            expect(@mock_api).to receive(:cb_post).with(Cb.configuration.uri_application_external, kind_of(Hash)).and_return({})
+          it 'posts the application as xml' do
+            stub_request(:post, uri_stem(Cb.configuration.uri_application_external))
+                .with(body: external_app.to_xml)
             submit_app(external_app)
           end
         end

--- a/spec/cb/clients/company_spec.rb
+++ b/spec/cb/clients/company_spec.rb
@@ -25,8 +25,8 @@ module Cb
         cb_api_client = double(Cb::Utils::Api)
         expect(cb_api_client).to receive(:cb_get).with(Cb.configuration.uri_company_find, query_hash).and_return({})
         allow(cb_api_client).to receive(:append_api_responses)
-        allow(Cb::Utils::Api).to receive(:new).and_return(cb_api_client)
 
+        allow(Cb::Clients::Company).to receive(:cb_client).and_return(cb_api_client)
         Cb::Clients::Company.find_by_did(target_did)
       end
 

--- a/spec/cb/clients/cover_letters_spec.rb
+++ b/spec/cb/clients/cover_letters_spec.rb
@@ -1,0 +1,86 @@
+# # Copyright 2015 CareerBuilder, LLC
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and limitations under the License.
+# require 'spec_helper'
+#
+# module Cb
+#   describe Cb::Clients::AnonSavedSearch.new do
+#     before :each do
+#       @args = {
+#         'EmailAddress' => 'test@test.com',
+#         'BrowserID'    => '123abc',
+#         'SessionID'    => 'abs123',
+#         'HostSite'     => 'WR',
+#         'DeveloperKey' => 'HOORAY!',
+#         'SearchName'   => 'fajitas',
+#         'Keywords'     => 'tortillas, steak, onions, peppers',
+#         'Location'     => 'atlanta',
+#         'IsDailyEmail' => 'none',
+#         'Test'         => 'false'
+#       }
+#     end
+#
+#     context '#create' do
+#       def stub_api_request
+#         stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_create))
+#           .with(body: anything)
+#           .to_return(body: @response_body.to_json)
+#       end
+#
+#       context 'when everything is working smoothly' do
+#         context 'should successfully create a new anonymous saved search via:' do
+#           def assert_no_error_on_model(&api_calling_code)
+#             saved_search_response = api_calling_code.call
+#             expect(saved_search_response.class).to eq Responses::AnonymousSavedSearch::Create
+#             model_class = saved_search_response.model.class
+#             expect(model_class).to eq Models::SavedSearch
+#           end
+#
+#           before :each do
+#             @response_body = { 'Errors' => '', 'ExternalID' => 'eid', 'AnonymousSavedSearch' => { 'things' => 'stuff' } }
+#             stub_api_request
+#           end
+#
+#           it 'the Cb module convenience method' do
+#             assert_no_error_on_model { Cb.anon_saved_search.create @args }
+#           end
+#
+#           it 'the anonymous saved search api client directly' do
+#             assert_no_error_on_model { Cb::Clients::AnonSavedSearch.create @args }
+#           end
+#         end
+#       end
+#     end # create
+#
+#     context '#delete' do
+#       context 'when everything is working smoothly' do
+#         def stub_api_request
+#           stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_delete.to_s))
+#             .with(body: anything)
+#             .to_return(body: { 'Errors' => '', 'Status' => 'Success' }.to_json)
+#         end
+#
+#         before :each do
+#           @args = {
+#             'ExternalID'   => 'yay',
+#             'Test'         => false,
+#             'DeveloperKey' => 'whoa'
+#           }
+#           stub_api_request
+#         end
+#
+#         it 'should successfully delete an anonymous saved search' do
+#           response = Cb.anon_saved_search.delete @args
+#           expect(response.model.status).to eq 'Success'
+#         end
+#       end
+#     end # delete
+#   end
+# end

--- a/spec/cb/clients/cover_letters_spec.rb
+++ b/spec/cb/clients/cover_letters_spec.rb
@@ -114,9 +114,29 @@ module Cb
         it 'returns the error hash' do
           stub = stub_request(:get, uri).
               with(:headers => headers).
-              to_return(:status => 404, :body => response.to_json)
+              to_return(:status => 404, :body => error_response.to_json)
 
           response = Cb::Clients::CoverLetters.get(id: 'id', oauth_token: 'token')
+          expect(stub).to have_been_requested
+          expect(response.class).to eq(Hash)
+          expect(response['errors'].class).to eq(Array)
+          expect(response['errors'].length).to eq(1)
+          expect(response['errors'][0]).to eq(data)
+        end
+      end
+    end
+
+    context '#delete' do
+      context 'asking for a specific cover letter' do
+        let(:data){ 'The cover letter was deleted successfully' }
+        let(:uri) { "https://api.careerbuilder.com/consumer/coverletters/id?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+
+        it 'performs a get and returns the coverletter asked for' do
+          stub = stub_request(:delete, uri).
+              with(:headers => headers).
+              to_return(:status => 200, :body => response.to_json)
+
+          response = Cb::Clients::CoverLetters.delete(id: 'id', oauth_token: 'token')
           expect(stub).to have_been_requested
           expect(response.class).to eq(Hash)
           expect(response['data'].class).to eq(Array)
@@ -124,7 +144,63 @@ module Cb
           expect(response['data'][0]).to eq(data)
         end
       end
+
+      context 'when an error occurs' do
+        let(:data){ { 'type' => '500', 'message' => 'Could not find the cover letter specified', 'code' => '404' } }
+        let(:uri) { "https://api.careerbuilder.com/consumer/coverletters/id?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+
+        it 'returns the error hash' do
+          stub = stub_request(:delete, uri).
+              with(:headers => headers).
+              to_return(:status => 500, :body => error_response.to_json)
+
+          response = Cb::Clients::CoverLetters.delete(id: 'id', oauth_token: 'token')
+          expect(stub).to have_been_requested
+          expect(response.class).to eq(Hash)
+          expect(response['errors'].class).to eq(Array)
+          expect(response['errors'].length).to eq(1)
+          expect(response['errors'][0]).to eq(data)
+        end
+      end
     end
 
+    context '#update' do
+      let(:post_data) { {'id' => 'id','text' => 'text', 'name' => 'name'} }
+      context 'when updating an existing coverletter' do
+        let(:data){ cover_letter }
+        let(:uri) { "https://api.careerbuilder.com/consumer/coverletters/id?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+
+        it 'performs a post and returns the updated coverletter asked for' do
+          stub = stub_request(:post, uri).
+              with(:body => post_data.to_json , :headers => headers).
+              to_return(:status => 200, :body => response.to_json)
+
+          response = Cb::Clients::CoverLetters.update(id: 'id',name: 'name', text: 'text', oauth_token: 'token')
+          expect(stub).to have_been_requested
+          expect(response.class).to eq(Hash)
+          expect(response['data'].class).to eq(Array)
+          expect(response['data'].length).to eq(1)
+          expect(response['data'][0]).to eq(data)
+        end
+      end
+
+      context 'when an error occurs' do
+        let(:data){ { 'type' => '500', 'message' => 'Could not find the cover letter specified', 'code' => '404' } }
+        let(:uri) { "https://api.careerbuilder.com/consumer/coverletters/id?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+
+        it 'returns the error hash' do
+          stub = stub_request(:post, uri).
+              with(:body => post_data.to_json, :headers => headers).
+              to_return(:status => 500, :body => error_response.to_json)
+
+          response = Cb::Clients::CoverLetters.update(id: 'id',name: 'name', text: 'text', oauth_token: 'token')
+          expect(stub).to have_been_requested
+          expect(response.class).to eq(Hash)
+          expect(response['errors'].class).to eq(Array)
+          expect(response['errors'].length).to eq(1)
+          expect(response['errors'][0]).to eq(data)
+        end
+      end
+    end
   end
 end

--- a/spec/cb/clients/cover_letters_spec.rb
+++ b/spec/cb/clients/cover_letters_spec.rb
@@ -1,86 +1,51 @@
-# # Copyright 2015 CareerBuilder, LLC
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and limitations under the License.
-# require 'spec_helper'
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# module Cb
-#   describe Cb::Clients::AnonSavedSearch.new do
-#     before :each do
-#       @args = {
-#         'EmailAddress' => 'test@test.com',
-#         'BrowserID'    => '123abc',
-#         'SessionID'    => 'abs123',
-#         'HostSite'     => 'WR',
-#         'DeveloperKey' => 'HOORAY!',
-#         'SearchName'   => 'fajitas',
-#         'Keywords'     => 'tortillas, steak, onions, peppers',
-#         'Location'     => 'atlanta',
-#         'IsDailyEmail' => 'none',
-#         'Test'         => 'false'
-#       }
-#     end
-#
-#     context '#create' do
-#       def stub_api_request
-#         stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_create))
-#           .with(body: anything)
-#           .to_return(body: @response_body.to_json)
-#       end
-#
-#       context 'when everything is working smoothly' do
-#         context 'should successfully create a new anonymous saved search via:' do
-#           def assert_no_error_on_model(&api_calling_code)
-#             saved_search_response = api_calling_code.call
-#             expect(saved_search_response.class).to eq Responses::AnonymousSavedSearch::Create
-#             model_class = saved_search_response.model.class
-#             expect(model_class).to eq Models::SavedSearch
-#           end
-#
-#           before :each do
-#             @response_body = { 'Errors' => '', 'ExternalID' => 'eid', 'AnonymousSavedSearch' => { 'things' => 'stuff' } }
-#             stub_api_request
-#           end
-#
-#           it 'the Cb module convenience method' do
-#             assert_no_error_on_model { Cb.anon_saved_search.create @args }
-#           end
-#
-#           it 'the anonymous saved search api client directly' do
-#             assert_no_error_on_model { Cb::Clients::AnonSavedSearch.create @args }
-#           end
-#         end
-#       end
-#     end # create
-#
-#     context '#delete' do
-#       context 'when everything is working smoothly' do
-#         def stub_api_request
-#           stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_delete.to_s))
-#             .with(body: anything)
-#             .to_return(body: { 'Errors' => '', 'Status' => 'Success' }.to_json)
-#         end
-#
-#         before :each do
-#           @args = {
-#             'ExternalID'   => 'yay',
-#             'Test'         => false,
-#             'DeveloperKey' => 'whoa'
-#           }
-#           stub_api_request
-#         end
-#
-#         it 'should successfully delete an anonymous saved search' do
-#           response = Cb.anon_saved_search.delete @args
-#           expect(response.model.status).to eq 'Success'
-#         end
-#       end
-#     end # delete
-#   end
-# end
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module Cb
+  describe Cb::Clients::CoverLetters do
+    let(:data) { {id: 'id', name: 'name', text: 'text'} }
+    let(:response) do
+      {
+          'data' => [
+              data
+          ],
+          'page' => 1,
+          'page_size' => 1,
+          'total' => 1
+      }
+    end
+    let(:headers) do
+      {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'deflate, gzip',
+          'Authorization'=>'Bearer token',
+          'Developerkey'=>'ruby-cb-api'
+      }
+    end
+    context '#create' do
+      it 'performs a put with a coverletter in json format' do
+        stub = stub_request(:put, "https://api.careerbuilder.com/consumer/coverletters?developerkey=ruby-cb-api&outputjson=true").
+            with(:body => "{\"text\":\"text\",\"name\":\"name\"}",
+                 :headers => headers).
+            to_return(:status => 200, :body => response.to_json)
+        response = Cb::Clients::CoverLetters.create(name: 'name', text: 'text', oauth_token: 'token')
+        expect(stub).to have_been_requested
+        expect(response.class).to eq(Hash)
+        expect(response['data'].class).to eq(Array)
+        expect(response['data'][0]).to eq(data)
+      end
+
+      
+    end
+
+  end
+end

--- a/spec/cb/clients/cover_letters_spec.rb
+++ b/spec/cb/clients/cover_letters_spec.rb
@@ -41,6 +41,7 @@ module Cb
           'Accept'=>'application/json',
           'Accept-Encoding'=>'deflate, gzip',
           'Authorization'=>'Bearer token',
+          'Content-Type' => 'application/json',
           'Developerkey'=> Cb.configuration.dev_key
       }
     end

--- a/spec/cb/clients/cover_letters_spec.rb
+++ b/spec/cb/clients/cover_letters_spec.rb
@@ -73,8 +73,8 @@ module Cb
     end
 
     context '#get' do
-      let(:data) { [cover_letter,cover_letter,cover_letter] }
       context 'asking for all cover letters' do
+        let(:data) { [cover_letter,cover_letter,cover_letter] }
         it 'performs a get and returns the results hash' do
           stub = stub_request(:get, uri).
               with(:headers => headers).
@@ -90,7 +90,39 @@ module Cb
       end
 
       context 'asking for a specific cover letter' do
+        let(:data){ cover_letter }
+        let(:uri) { "https://api.careerbuilder.com/consumer/coverletters/id?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
 
+        it 'performs a get and returns the coverletter asked for' do
+          stub = stub_request(:get, uri).
+              with(:headers => headers).
+              to_return(:status => 200, :body => response.to_json)
+
+          response = Cb::Clients::CoverLetters.get(id: 'id', oauth_token: 'token')
+          expect(stub).to have_been_requested
+          expect(response.class).to eq(Hash)
+          expect(response['data'].class).to eq(Array)
+          expect(response['data'].length).to eq(1)
+          expect(response['data'][0]).to eq(cover_letter)
+        end
+      end
+
+      context 'when the cover letter is not found' do
+        let(:data){ { 'type' => '404', 'message' => 'Could not find the cover letter specified', 'code' => '404' } }
+        let(:uri) { "https://api.careerbuilder.com/consumer/coverletters/id?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+
+        it 'returns the error hash' do
+          stub = stub_request(:get, uri).
+              with(:headers => headers).
+              to_return(:status => 404, :body => response.to_json)
+
+          response = Cb::Clients::CoverLetters.get(id: 'id', oauth_token: 'token')
+          expect(stub).to have_been_requested
+          expect(response.class).to eq(Hash)
+          expect(response['data'].class).to eq(Array)
+          expect(response['data'].length).to eq(1)
+          expect(response['data'][0]).to eq(data)
+        end
       end
     end
 

--- a/spec/cb/clients/education_spec.rb
+++ b/spec/cb/clients/education_spec.rb
@@ -23,7 +23,7 @@ module Cb
         before :each do
           allow(mock_api).to receive(:append_api_responses)
           allow(mock_api).to receive(:cb_get).and_return({})
-          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Clients::Education).to receive(:cb_client).and_return(mock_api)
         end
 
         it 'calls #append_api_responses on the Cb API utility client' do

--- a/spec/cb/clients/employee_types_spec.rb
+++ b/spec/cb/clients/employee_types_spec.rb
@@ -12,21 +12,12 @@ require 'spec_helper'
 
 module Cb
   describe Clients::EmployeeTypes do
-    let(:client_under_test) { Clients::EmployeeTypes.new }
-    let(:cb_api_client)     { (Cb.api_client.new) }
-
     before(:each) do
       allow(cb_api_client).to receive(:cb_get).and_return('bananas' => '4life')
       allow(Cb.api_client).to receive(:new).and_return(cb_api_client)
       response = double(Responses::EmployeeTypes::Search)
       allow(response).to receive(:class).and_return Responses::EmployeeTypes::Search
       allow(Responses::EmployeeTypes::Search).to receive(:new).and_return(response)
-    end
-
-    context '#new' do
-      it 'returns a type of Cb::Clients::EmployeeTypes' do
-        expect(Clients::EmployeeTypes.new.class).to eq Cb::Clients::EmployeeTypes
-      end
     end
 
     def returns_response_object(method, *args)

--- a/spec/cb/clients/saved_search_spec.rb
+++ b/spec/cb/clients/saved_search_spec.rb
@@ -13,13 +13,6 @@ require 'support/mocks/saved_search'
 
 module Cb
   describe Cb::Clients::SavedSearch do
-    context '.new' do
-      it 'should create a new saved job search api object' do
-        saved_search_request = Cb::Clients::SavedSearch
-        expect(saved_search_request).to be_a_kind_of(Cb::Clients::SavedSearch)
-      end
-    end
-
     context '.create' do
       before :each do
         stub_request(:post, uri_stem(Cb.configuration.uri_saved_search_create))
@@ -34,7 +27,7 @@ module Cb
                                         'ExternalUserID' => @external_user_id, 'SearchName' => search_name,
                                         'HostSite' => @host_site)
 
-        expect(Cb.saved_search.new.create(model).class).to eq Responses::SavedSearch::Singular
+        expect(Cb.saved_search.create(model).class).to eq Responses::SavedSearch::Singular
       end
     end
 

--- a/spec/cb/clients/saved_search_spec.rb
+++ b/spec/cb/clients/saved_search_spec.rb
@@ -15,7 +15,7 @@ module Cb
   describe Cb::Clients::SavedSearch do
     context '.new' do
       it 'should create a new saved job search api object' do
-        saved_search_request = Cb::Clients::SavedSearch.new
+        saved_search_request = Cb::Clients::SavedSearch
         expect(saved_search_request).to be_a_kind_of(Cb::Clients::SavedSearch)
       end
     end
@@ -56,7 +56,7 @@ module Cb
                                           'DID' => external_id, 'SearchName' => search_name,
                                           'HostSite' => 'GR', 'userOAuthToken' => oauth)
 
-          response = Cb.saved_search.new.update(model)
+          response = Cb.saved_search.update(model)
           expect(response.model.class).to eq Models::SavedSearch
         end
       end
@@ -78,7 +78,7 @@ module Cb
                                           'DID' => external_id, 'SearchName' => search_name,
                                           'HostSite' => nil, 'userOAuthToken' => oauth)
 
-          response = Cb.saved_search.new.update(model)
+          response = Cb.saved_search.update(model)
           expect(response.model.class).to eq Models::SavedSearch
         end
       end
@@ -92,7 +92,7 @@ module Cb
         end
 
         it 'should return an array of saved searches' do
-          user_saved_search = Cb.saved_search.new.list(@user_oauth_token, 'WR')
+          user_saved_search = Cb.saved_search.list(@user_oauth_token, 'WR')
           expect(user_saved_search.models).to be_an_instance_of Array
           expect(user_saved_search.models.count).to eq(2)
           expect(user_saved_search.models.first).to be_an_instance_of Cb::Models::SavedSearch
@@ -106,7 +106,7 @@ module Cb
         end
 
         it 'should return an array of saved searches' do
-          user_saved_search = Cb.saved_search.new.list(@user_oauth_token, 'WR')
+          user_saved_search = Cb.saved_search.list(@user_oauth_token, 'WR')
           expect(user_saved_search.models).to be_an_instance_of Array
           expect(user_saved_search.models.count).to eq(0)
         end
@@ -137,7 +137,7 @@ module Cb
       end
 
       it 'should return a saved search model' do
-        response = Cb::Clients::SavedSearch.new.retrieve(@user_oauth_token, 'xid')
+        response = Cb::Clients::SavedSearch.retrieve(@user_oauth_token, 'xid')
         expect(response.model).to be_an_instance_of(Models::SavedSearch)
       end
     end
@@ -151,7 +151,7 @@ module Cb
 
       it 'should delete a saved search without error' do
         hash = { did: 'xid', user_oauth_token: 'oauth', host_site: 'host site' }
-        Cb.saved_search.new.delete(hash)
+        Cb.saved_search.delete(hash)
       end
     end
   end


### PR DESCRIPTION
Refactoring of the clients.  Breaking changes to AnonSavedSearch, EmployeeTypes, SavedSearch because they were switched to class methods instead of instance methods in order to match the other old style clients.

New coverletters api works like this:
List all coverletters 
```ruby
Cb.cover_letters.get(oauth_token: token)
```
Retrieve one coverletter 
```ruby
Cb.cover_letters.get(id: 'CLXXXXXXXXXXXXXX', oauth_token: token)
```
Create one coverletter
```ruby
Cb.cover_letters.create(name: 'name 1', text: 'text 1', oauth_token: token)
```
Update coverletter 
```ruby
Cb.cover_letters.update(id:'CXXXXXX'; name: 'name 1', text: 'text 1', oauth_token: token)
```
Delete coverletter 
```ruby
Cb.cover_letters.delete(id:'CXXXXXX', oauth_token: token)
```