### PR TITLE
Revert resume list changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
-* 20.0.0 Remove Migration ID field from resume listing model.
+* 20.1.0 Remove Migration ID field from resume listing model.
 * 20.0.0 Refactoring of the clients.  Breaking changes to AnonSavedSearch, EmployeeTypes, SavedSearch
 * 19.1.1 No functional differences, some code cleanup
 * 19.1.0 Add Migration ID field to resume listing model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
-
+* 20.0.0 Remove Migration ID field from resume listing model.
 * 20.0.0 Refactoring of the clients.  Breaking changes to AnonSavedSearch, EmployeeTypes, SavedSearch
 * 19.1.1 No functional differences, some code cleanup
 * 19.1.0 Add Migration ID field to resume listing model.

--- a/lib/cb/models/implementations/resume_listing.rb
+++ b/lib/cb/models/implementations/resume_listing.rb
@@ -11,12 +11,11 @@
 module Cb
   module Models
     class ResumeListing < ApiResponseModel
-      attr_accessor :title, :external_id, :migration_id, :host_site, :modified_dt, :visibility
+      attr_accessor :title, :external_id, :host_site, :modified_dt, :visibility
 
       def set_model_properties
         @title = api_response['Title']
         @external_id = api_response['ExternalID']
-        @migration_id = api_response['MigrationID'] unless api_response['MigrationID'].nil?
         @host_site = api_response['HostSite']
         @modified_dt = api_response['ModifiedDT']
         @visibility = api_response['Visibility']

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '20.0.0'
+  VERSION = '20.1.0'
 end

--- a/spec/cb/models/implementations/resume_listing_spec.rb
+++ b/spec/cb/models/implementations/resume_listing_spec.rb
@@ -16,7 +16,6 @@ module Cb
       let(:resume_listing) { Models::ResumeListing.new(resume_list_hash) }
       let(:resume_list_hash) do
         {
-          'MigrationID' => 'migrationID',
           'Title' => 'Software Engineer',
           'ExternalID' => 'externalID',
           'HostSite' => 'US',
@@ -27,24 +26,9 @@ module Cb
 
       it { expect(resume_listing.title).to eq('Software Engineer') }
       it { expect(resume_listing.external_id).to eq('externalID') }
-      it { expect(resume_listing.migration_id).to eq('migrationID') }
       it { expect(resume_listing.host_site).to eq('US') }
       it { expect(resume_listing.modified_dt).to eq('2/16/2016 11:08:11 AM') }
       it { expect(resume_listing.visibility).to eq('Private') }
-
-      context 'listing does not contain a migration ID' do
-        let(:resume_list_hash) do
-          {
-              'Title' => 'Software Engineer',
-              'ExternalID' => 'externalID',
-              'HostSite' => 'US',
-              'ModifiedDT' => '2/16/2016 11:08:11 AM',
-              'Visibility' => 'Private'
-          }
-        end
-
-        it { expect(resume_listing.migration_id.nil?).to be(true) }
-      end
     end
   end
 end


### PR DESCRIPTION
We no longer need the migration ID to be passed through. Removing it.