### PR TITLE
trying not to break peeeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
-* 20.1.1 Having nilreponse behave more like we did pre ruby 2.2 so as not to break downstream peeps
+* 20.1.1 Having nil reponses behave more like we did pre ruby 2.2 so as not to break downstream peeps
 * 20.1.0 Remove Migration ID field from resume listing model.
 * 20.0.0 Refactoring of the clients.  Breaking changes to AnonSavedSearch, EmployeeTypes, SavedSearch
 * 19.1.1 No functional differences, some code cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 20.1.1 Having nilreponse behave more like we did pre ruby 2.2 so as not to break downstream peeps
 * 20.1.0 Remove Migration ID field from resume listing model.
 * 20.0.0 Refactoring of the clients.  Breaking changes to AnonSavedSearch, EmployeeTypes, SavedSearch
 * 19.1.1 No functional differences, some code cleanup

--- a/lib/cb/utils/nil_response.rb
+++ b/lib/cb/utils/nil_response.rb
@@ -20,7 +20,7 @@ module Cb
         true
       end
 
-      # We used to monkey patch Nil to reponds to all methods on the api client
+      # We used to monkey patch Nil to responds to all methods on the api client
       def method_missing(m, *args, &block)
         return nil
       end

--- a/lib/cb/utils/nil_response.rb
+++ b/lib/cb/utils/nil_response.rb
@@ -15,9 +15,16 @@ module Cb
   module Utils
     class NilResponse
       def initialize ;end
+
       def nil?
         true
       end
+
+      # We used to monkey patch Nil to reponds to all methods on the api client
+      def method_missing(m, *args, &block)
+        return nil
+      end
+
     end
   end
 end

--- a/lib/cb/utils/nil_response.rb
+++ b/lib/cb/utils/nil_response.rb
@@ -20,7 +20,7 @@ module Cb
         true
       end
 
-      # We used to monkey patch Nil to responds to all methods on the api client
+      # We used to monkey patch Nil to respond to all methods on the api client
       def method_missing(m, *args, &block)
         return nil
       end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '20.1.0'
+  VERSION = '20.1.1'
 end


### PR DESCRIPTION
With ruby 2.2 we can no longer mess with Nil since it is frozen so we instead choose to send a fake nil that is patched.  This makes it behave a bit more like it did pre ruby 2.2 so we don't get errors like this when the API fails to return us the model we were looking for
![screenshot 2016-03-07 13 11 42](https://cloud.githubusercontent.com/assets/882850/13578493/48637cc8-e466-11e5-80a5-ea3f874eea47.png)
