### PR TITLE
Add posting_date to job model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 20.4.0 Add posting_date to recommendations for job model.
 * 20.3.0 Add new resume list API (/consumer/resumes)
 * 20.2.1 `class << self` for classes with all class methods. DRY up the URI building for Cover Letter Update & Delete.
 * 20.2.0 Adding job insights client

--- a/lib/cb/models/implementations/job.rb
+++ b/lib/cb/models/implementations/job.rb
@@ -20,7 +20,7 @@ module Cb
                     :location, :distance, :latitude, :longitude, :location_formatted, :location_metro_city,
                     :description, :requirements, :employment_type,
                     :details_url, :service_url, :similar_jobs_url, :apply_url,
-                    :begin_date, :end_date, :posted_date, :posted_time,
+                    :begin_date, :end_date, :posted_date, :posted_time, :posting_date,
                     :relevancy, :state, :city, :zip,
                     :can_be_quick_applied, :apply_requirements,
                     :divison, :industry, :location_street_1, :relocation_options, :location_street_2, :display_job_id,
@@ -177,6 +177,7 @@ module Cb
         @state                        = args['LocationState'] || ''
         @city                         = args['LocationCity'] || ''
         @zip                          = args['LocationPostalCode'] || ''
+        @posting_date                 = args['PostingDate'] || ''
 
         @company_name            = figure_out_company_info(args['Company'], args['Company'], 'CompanyName')
         @company_details_url     = figure_out_company_info(args['CompanyDetailsURL'], args['Company'], 'CompanyDetailsURL')

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '20.3.0'
+  VERSION = '20.4.0'
 end

--- a/spec/cb/models/implementations/job_spec.rb
+++ b/spec/cb/models/implementations/job_spec.rb
@@ -29,13 +29,13 @@ module Cb::Models
     # to the set of mappings below and it will test itself for you!
     context 'predicate methods:' do
       response_to_model_mappings = [
-          { api_field: 'HasQuestionnaire',    predicate_method: :has_questionnaire? },
-          { api_field: 'CanBeQuickApplied',   predicate_method: :can_be_quick_applied? },
-          { api_field: 'ManagesOthers',       predicate_method: :manages_others? },
-          { api_field: 'IsScreenerApply',     predicate_method: :screener_apply? },
-          { api_field: 'IsSharedJob',         predicate_method: :shared_job? },
-          { api_field: 'RelocationCovered',   predicate_method: :relocation_covered? },
-          { api_field: 'ExternalApplication', predicate_method: :external_application? }
+        { api_field: 'HasQuestionnaire',    predicate_method: :has_questionnaire? },
+        { api_field: 'CanBeQuickApplied',   predicate_method: :can_be_quick_applied? },
+        { api_field: 'ManagesOthers',       predicate_method: :manages_others? },
+        { api_field: 'IsScreenerApply',     predicate_method: :screener_apply? },
+        { api_field: 'IsSharedJob',         predicate_method: :shared_job? },
+        { api_field: 'RelocationCovered',   predicate_method: :relocation_covered? },
+        { api_field: 'ExternalApplication', predicate_method: :external_application? }
       ]
 
       response_to_model_mappings.each do |mapping|

--- a/spec/cb/models/implementations/job_spec.rb
+++ b/spec/cb/models/implementations/job_spec.rb
@@ -29,13 +29,13 @@ module Cb::Models
     # to the set of mappings below and it will test itself for you!
     context 'predicate methods:' do
       response_to_model_mappings = [
-        { api_field: 'HasQuestionnaire',    predicate_method: :has_questionnaire? },
-        { api_field: 'CanBeQuickApplied',   predicate_method: :can_be_quick_applied? },
-        { api_field: 'ManagesOthers',       predicate_method: :manages_others? },
-        { api_field: 'IsScreenerApply',     predicate_method: :screener_apply? },
-        { api_field: 'IsSharedJob',         predicate_method: :shared_job? },
-        { api_field: 'RelocationCovered',   predicate_method: :relocation_covered? },
-        { api_field: 'ExternalApplication', predicate_method: :external_application? }
+          { api_field: 'HasQuestionnaire',    predicate_method: :has_questionnaire? },
+          { api_field: 'CanBeQuickApplied',   predicate_method: :can_be_quick_applied? },
+          { api_field: 'ManagesOthers',       predicate_method: :manages_others? },
+          { api_field: 'IsScreenerApply',     predicate_method: :screener_apply? },
+          { api_field: 'IsSharedJob',         predicate_method: :shared_job? },
+          { api_field: 'RelocationCovered',   predicate_method: :relocation_covered? },
+          { api_field: 'ExternalApplication', predicate_method: :external_application? }
       ]
 
       response_to_model_mappings.each do |mapping|
@@ -68,6 +68,24 @@ module Cb::Models
               expect(job.send(predicate_method)).to be_falsey
             end
           end
+        end
+      end
+    end
+
+    describe 'set_model_properties' do
+      let(:response_stub) do
+        full_response = JSON.parse(File.read('spec/support/response_stubs/recommendations_for_job.json'))
+        full_response
+      end
+
+      context 'when the response json comes back correctly' do
+        it 'initializes model without exception' do
+          Cb::Models::Job.new(response_stub)
+        end
+
+        it 'parses fields correctly' do
+          model = Cb::Models::Job.new(response_stub)
+          expect(model.posting_date).to eq '3/3/2016 12:00:00 AM'
         end
       end
     end

--- a/spec/cb/models/implementations/job_spec.rb
+++ b/spec/cb/models/implementations/job_spec.rb
@@ -68,24 +68,23 @@ module Cb::Models
               expect(job.send(predicate_method)).to be_falsey
             end
           end
-        end
-      end
-    end
 
-    describe 'set_model_properties' do
-      let(:response_stub) do
-        full_response = JSON.parse(File.read('spec/support/response_stubs/recommendations_for_job.json'))
-        full_response
-      end
+          context 'when the response json comes back correctly' do
+            let(:response_stub) do
+              full_response = JSON.parse(File.read('spec/support/response_stubs/recommendations_for_job.json'))
+              recommend_job_response = full_response['ResponseRecommendJob']
+              recommend_job_response['RecommendJobResults']['RecommendJobResult'].first
+            end
 
-      context 'when the response json comes back correctly' do
-        it 'initializes model without exception' do
-          Cb::Models::Job.new(response_stub)
-        end
+            it 'initializes model without exception' do
+              Cb::Models::Job.new(response_stub)
+            end
 
-        it 'parses fields correctly' do
-          model = Cb::Models::Job.new(response_stub)
-          expect(model.posting_date).to eq '3/3/2016 12:00:00 AM'
+            it 'parses fields correctly' do
+              model = Cb::Models::Job.new(response_stub)
+              expect(model.posting_date).to eq '2/19/2016 12:00:00 AM'
+            end
+          end
         end
       end
     end

--- a/spec/support/response_stubs/recommendations_for_job.json
+++ b/spec/support/response_stubs/recommendations_for_job.json
@@ -1,0 +1,35 @@
+{
+  "JobDID": "J3G4QV5ZZV8DWNFT041",
+  "Title": "Sous Chef",
+  "Relevancy": "1",
+  "Location": {
+    "State": "DC",
+    "City": "Washington"
+  },
+  "Company": {
+    "CompanyName": "The Capital Grille",
+    "CompanyDetailsURL": "nil",
+    "CompanyDID": "nil"
+  },
+  "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=J3G4QV5ZZV8DWNFT041",
+  "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=J3G4QV5ZZV8DWNFT041",
+  "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=JELO&job_did=J3G4QV5ZZV8DWNFT041",
+  "ONet": "35-1011.00",
+  "ONetFriendlyTitle": "Chefs and Head Cooks",
+  "HostSite": "US",
+  "PostingDate": "3/3/2016 12:00:00 AM",
+  "CanBeQuickApplied": "False",
+  "MatcherType": "CX",
+  "EducationRequired": "Not Specified",
+  "Skills": "nil",
+  "EmploymentType": "Full-Time",
+  "ExperienceRequired": "Not Specified",
+  "Pay": "$55k - $70k/year",
+  "Categories": {
+    "Category": ["JN035", "JN040"]
+  },
+  "JobLevel": "4",
+  "ApplyRequirements": {
+    "ApplyRequirement": "IsExternal"
+  }
+}

--- a/spec/support/response_stubs/recommendations_for_job.json
+++ b/spec/support/response_stubs/recommendations_for_job.json
@@ -1,35 +1,192 @@
 {
-  "JobDID": "J3G4QV5ZZV8DWNFT041",
-  "Title": "Sous Chef",
-  "Relevancy": "1",
-  "Location": {
-    "State": "DC",
-    "City": "Washington"
-  },
-  "Company": {
-    "CompanyName": "The Capital Grille",
-    "CompanyDetailsURL": "nil",
-    "CompanyDID": "nil"
-  },
-  "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=J3G4QV5ZZV8DWNFT041",
-  "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=J3G4QV5ZZV8DWNFT041",
-  "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=JELO&job_did=J3G4QV5ZZV8DWNFT041",
-  "ONet": "35-1011.00",
-  "ONetFriendlyTitle": "Chefs and Head Cooks",
-  "HostSite": "US",
-  "PostingDate": "3/3/2016 12:00:00 AM",
-  "CanBeQuickApplied": "False",
-  "MatcherType": "CX",
-  "EducationRequired": "Not Specified",
-  "Skills": "nil",
-  "EmploymentType": "Full-Time",
-  "ExperienceRequired": "Not Specified",
-  "Pay": "$55k - $70k/year",
-  "Categories": {
-    "Category": ["JN035", "JN040"]
-  },
-  "JobLevel": "4",
-  "ApplyRequirements": {
-    "ApplyRequirement": "IsExternal"
+  "ResponseRecommendJob": {
+    "Errors": "nil",
+    "Request": {
+      "DeveloperKey": "",
+      "SiteID": "nil",
+      "CoBrand": "nil",
+      "JobDID": "J9063C6D5MTV0Q8V6WK",
+      "CountLimit": "5",
+      "MinQualityLimit": "0",
+      "RequestSource": "rechq",
+      "RequestEvidenceID": "a444e31e-e34d-4b5c-bc8c-ec6975933cd0"
+    },
+    "TimeResponseSent": "3/17/2016 3:33:19 PM",
+    "TimeElapsed": "0.4992",
+    "RecommendJobResults": {
+      "RecommendJobResult": [{
+        "JobDID": "JHQ2WF74PK8690FJQHM",
+        "Title": "Housekeeper/Laundry Aide",
+        "Relevancy": "1",
+        "Location": {
+          "State": "MD",
+          "City": "Timonium"
+        },
+        "Company": {
+          "CompanyName": "Lorien Health Systems",
+          "CompanyDetailsURL": "http://www.careerbuilder.com/jobs/company/cht0x96xq0gpbgbqv7v/lorien-health-systems?sc_cmp1=13_JobRes_ComDet",
+          "CompanyDID": "CHT0X96XQ0GPBGBQV7V"
+        },
+        "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=JHQ2WF74PK8690FJQHM",
+        "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=JHQ2WF74PK8690FJQHM",
+        "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=bbb&job_did=JHQ2WF74PK8690FJQHM",
+        "ONet": "37-2012.00",
+        "ONetFriendlyTitle": "Maids and Housekeeping Cleaners",
+        "HostSite": "US",
+        "PostingDate": "2/19/2016 12:00:00 AM",
+        "CanBeQuickApplied": "False",
+        "MatcherType": "CX",
+        "EducationRequired": "Not Specified",
+        "Skills": "nil",
+        "EmploymentType": "Full-Time",
+        "ExperienceRequired": "Not Specified",
+        "Pay": "N/A",
+        "Categories": {
+          "Category": ["JN010", "JN023", "JN017", "JN040"]
+        },
+        "JobLevel": "2",
+        "ApplyRequirements": {
+          "ApplyRequirement": "HasScreener"
+        }
+      }, {
+        "JobDID": "J3F4T96L8QJRS47XD00",
+        "Title": "Housekeeper",
+        "Relevancy": "1",
+        "Location": {
+          "State": "MD",
+          "City": "Severna Park"
+        },
+        "Company": {
+          "CompanyName": "nil",
+          "CompanyDetailsURL": "nil",
+          "CompanyDID": "nil"
+        },
+        "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=J3F4T96L8QJRS47XD00",
+        "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=J3F4T96L8QJRS47XD00",
+        "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=ll&job_did=J3F4T96L8QJRS47XD00",
+        "ONet": "37-2012.00",
+        "ONetFriendlyTitle": "Maids and Housekeeping Cleaners",
+        "HostSite": "US",
+        "PostingDate": "3/2/2016 12:00:00 AM",
+        "CanBeQuickApplied": "False",
+        "MatcherType": "CX",
+        "EducationRequired": "Not Specified",
+        "Skills": "nil",
+        "EmploymentType": "Full-Time",
+        "ExperienceRequired": "Not Specified",
+        "Pay": "N/A",
+        "Categories": {
+          "Category": ["JN010", "JN040", "JN017"]
+        },
+        "JobLevel": "2",
+        "ApplyRequirements": {
+          "ApplyRequirement": "NoOnlineApply"
+        }
+      }, {
+        "JobDID": "J3F7TB6X9W3LZX5MDN1",
+        "Title": "HOUSE CLEANING SERVICE",
+        "Relevancy": "1",
+        "Location": {
+          "State": "MD",
+          "City": "Annapolis"
+        },
+        "Company": {
+          "CompanyName": "nil",
+          "CompanyDetailsURL": "nil",
+          "CompanyDID": "nil"
+        },
+        "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=J3F7TB6X9W3LZX5MDN1",
+        "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=J3F7TB6X9W3LZX5MDN1",
+        "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=gh&job_did=J3F7TB6X9W3LZX5MDN1",
+        "ONet": "37-2012.00",
+        "ONetFriendlyTitle": "Maids and Housekeeping Cleaners",
+        "HostSite": "US",
+        "PostingDate": "3/5/2016 12:00:00 AM",
+        "CanBeQuickApplied": "False",
+        "MatcherType": "CX",
+        "EducationRequired": "Not Specified",
+        "Skills": "nil",
+        "EmploymentType": "Full-Time",
+        "ExperienceRequired": "Not Specified",
+        "Pay": "N/A",
+        "Categories": {
+          "Category": ["JN013", "JN022"]
+        },
+        "JobLevel": "2",
+        "ApplyRequirements": {
+          "ApplyRequirement": "NoOnlineApply"
+        }
+      }, {
+        "JobDID": "J3J85B6DP6Y702QQ6DR",
+        "Title": "Housekeeping Job Fair March 4th 9am-12pm",
+        "Relevancy": "1",
+        "Location": {
+          "State": "MD",
+          "City": "Parkville"
+        },
+        "Company": {
+          "CompanyName": "Erickson Living",
+          "CompanyDetailsURL": "http://www.careerbuilder.com/jobs/company/c8g3035vts4gq2zccrb/erickson-living?sc_cmp1=13_JobRes_ComDet",
+          "CompanyDID": "C8G3035VTS4GQ2ZCCRB"
+        },
+        "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=J3J85B6DP6Y702QQ6DR",
+        "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=J3J85B6DP6Y702QQ6DR",
+        "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=lo&job_did=J3J85B6DP6Y702QQ6DR",
+        "ONet": "99-9999.99",
+        "ONetFriendlyTitle": "Unclassified",
+        "HostSite": "US",
+        "PostingDate": "2/23/2016 12:00:00 AM",
+        "CanBeQuickApplied": "True",
+        "MatcherType": "CX",
+        "EducationRequired": "Not Specified",
+        "Skills": "nil",
+        "EmploymentType": "Full-Time",
+        "ExperienceRequired": "Not Specified",
+        "Pay": "N/A",
+        "Categories": {
+          "Category": ["JN035", "JN017", "JN040"]
+        },
+        "JobLevel": "2",
+        "ApplyRequirements": {
+          "ApplyRequirement": "CanBulkApply"
+        }
+      }, {
+        "JobDID": "J3L09Y6VJ4Q2YZR0ZBC",
+        "Title": "Laundry Attendant - Part Time",
+        "Relevancy": "1",
+        "Location": {
+          "State": "MD",
+          "City": "Bel Air"
+        },
+        "Company": {
+          "CompanyName": "Homewood Suites",
+          "CompanyDetailsURL": "http://www.careerbuilder.com/jobs/company/chn0wq6kh9zbcky90pl/homewood-suites?sc_cmp1=13_JobRes_ComDet",
+          "CompanyDID": "CHN0WQ6KH9ZBCKY90PL"
+        },
+        "JobDetailsURL": "http://api.careerbuilder.com/v1/joblink?TrackingID&DID=J3L09Y6VJ4Q2YZR0ZBC",
+        "JobServiceURL": "http://api.careerbuilder.com/v1/job?DID=J3L09Y6VJ4Q2YZR0ZBC",
+        "SimilarJobsURL": "http://www.careerbuilder.com/jobs/similarjobs.aspx?ipath=jj&job_did=J3L09Y6VJ4Q2YZR0ZBC",
+        "ONet": "37-2012.00",
+        "ONetFriendlyTitle": "Maids and Housekeeping Cleaners",
+        "HostSite": "US",
+        "PostingDate": "3/5/2016 12:00:00 AM",
+        "CanBeQuickApplied": "False",
+        "MatcherType": "CX",
+        "EducationRequired": "Not Specified",
+        "Skills": "nil",
+        "EmploymentType": "Part-Time",
+        "ExperienceRequired": "Not Specified",
+        "Pay": "N/A",
+        "Categories": {
+          "Category": ["JN003", "JN040", "JN017"]
+        },
+        "JobLevel": "2",
+        "ApplyRequirements": {
+          "ApplyRequirement": "IsExternal"
+        }
+      }]
+    },
+    "SearchMetaData": {
+    }
   }
 }


### PR DESCRIPTION
We are adding 'posting_date' to the job model for when we get recommendations for a job.

````
"PostingDate": "2/19/2016 12:00:00 AM",
`````
We had three options:
1. Add 'posting_date' to the existing job model that is passed to the consuming app.
2. Use new recs api instead and make sure to include 'posting_date'.
3. Rearchitect the API to pass the response hash, and then handle all the mappings in the consuming app. 


We ended up going with option 1 because it would be a quick turn around to deliver value of moving forward towards the migration of Matrix to GRRP. We would like to push the pulling through of any new implementations/recs version upgrade since we are able to accomplish what we need by a few simple changes.
