### PR TITLE
Adding more informative error message to api_response

### DIFF
--- a/lib/cb/responses/api_response.rb
+++ b/lib/cb/responses/api_response.rb
@@ -49,7 +49,7 @@ module Cb
       def required_response_field(field_name, parent_hash)
         fail ArgumentError.new("field_name can't be nil!")  if field_name.nil?
         fail ArgumentError.new("parent_hash can't be nil!") if parent_hash.nil?
-        fail ExpectedResponseFieldMissing.new(field_name) unless parent_hash.key?(field_name)
+        fail ExpectedResponseFieldMissing.new("Response field missing '#{field_name}' for #{self.class.name}") unless parent_hash.key?(field_name)
       end
 
       private

--- a/spec/cb/responses/api_response_spec.rb
+++ b/spec/cb/responses/api_response_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 # Copyright 2015 CareerBuilder, LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/cb/responses/api_response_spec.rb
+++ b/spec/cb/responses/api_response_spec.rb
@@ -81,6 +81,7 @@ module Cb
 
       let(:model_hashes) { [{ 'huzzah' => 'thangs' }] }
       let(:valid_input_hash) { { 'ResponseStuff' => { 'stuff' => model_hashes } } }
+      let(:other_input_hash) { { 'ResponseStuff' => { 'other_stuff' => model_hashes } } }
       let(:errored_input_hash) { { 'ResponseStuff' => { 'errors' => { 'error' => ['oh noes!', 'bah!'] }, :stuff => model_hashes } } }
 
       context 'when the input hash has all fields and all methods overridden' do
@@ -115,6 +116,15 @@ module Cb
           # #errors delegates to a different object with its own suite of tests
           it 'returns an errors object' do
             expect(DumbValidResponse.new(valid_input_hash).respond_to?(:errors)).to eq true
+          end
+        end
+        
+        context 'missing required field' do
+          it 'throws ExpectedResponseFieldMissing with specific error message' do
+            expect{DumbValidResponse.new(other_input_hash)}.
+                to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+              expect(ex.message).to eql("Response field missing 'stuff' for Cb::DumbValidResponse")
+            end
           end
         end
       end


### PR DESCRIPTION
from consumer tech debt card... Ruby-cb-api: make error for "missing response field" better.