### PR TITLE
Add error message to error raised from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 21.3.1 Add error message to error raised from API
 * 21.3.0 Add better error message to MissingRequiredField error in api_response
 * 21.2.0 Add User Profile API (/consumer/user-profile)
 * 21.1.0 Add expired job API (/v1/job/expired)

--- a/lib/cb/utils/validator.rb
+++ b/lib/cb/utils/validator.rb
@@ -31,10 +31,12 @@ module Cb
       end
 
       def fail_with_error_details(response, error_type)
-        error = error_type.new
+        processed_response = process_response_body(response)
+        error_message = processed_response['errors'] ? processed_response['errors'][0] : nil
+        error = error_type.new(error_message)
         error.code = response.code rescue nil
         error.raw_response = response
-        error.response = process_response_body(response)
+        error.response = processed_response
         fail error
       end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.3.0'
+  VERSION = '21.3.1'
 end

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -64,9 +64,12 @@ module Cb
       end
 
       it 'when status code is 500' do
-        allow(response.response).to receive(:body).and_return('{"errors":[]}')
+        allow(response.response).to receive(:body).and_return('{"errors":["Something went terribly wrong."]}')
         allow(response).to receive(:code).and_return 500
-        expect { ResponseValidator.validate(response) }.to raise_error(Cb::ServerError)
+        expect { ResponseValidator.validate(response) }.to raise_error do |error|
+          expect(error.message).to eq 'Something went terribly wrong.'
+          expect(error).to be_a Cb::ServerError
+        end
       end
 
       it 'when status code is 403' do


### PR DESCRIPTION
We get a bunch of `Cb::ServerError`s with the message also set to `Cb::ServerError`, which isn't helpful. New Relic cannot group errors with them all set to this. This is an attempt to fix that, at least for the APIs that follow the standard (uses an 'errors' node which is an array of strings).