### PR TITLE
Use `.first` and return emtpy string when no errors node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 21.3.2 Follow style guide more closely and use `.first` + return empty string when no errors node
 * 21.3.1 Add error message to error raised from API
 * 21.3.0 Add better error message to MissingRequiredField error in api_response
 * 21.2.0 Add User Profile API (/consumer/user-profile)

--- a/lib/cb/utils/validator.rb
+++ b/lib/cb/utils/validator.rb
@@ -32,7 +32,7 @@ module Cb
 
       def fail_with_error_details(response, error_type)
         processed_response = process_response_body(response)
-        error_message = processed_response['errors'] ? processed_response['errors'][0] : nil
+        error_message = processed_response['errors'] ? processed_response['errors'].first : ''
         error = error_type.new(error_message)
         error.code = response.code rescue nil
         error.raw_response = response

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.3.1'
+  VERSION = '21.3.2'
 end

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -72,6 +72,15 @@ module Cb
         end
       end
 
+      it 'when status code is 500 without errors node' do
+        allow(response.response).to receive(:body).and_return('{}')
+        allow(response).to receive(:code).and_return 500
+        expect { ResponseValidator.validate(response) }.to raise_error do |error|
+          expect(error.message).to eq ''
+          expect(error).to be_a Cb::ServerError
+        end
+      end
+
       it 'when status code is 403' do
         allow(response.response).to receive(:body).and_return('{"errors":[]}')
         allow(response).to receive(:code).and_return 400


### PR DESCRIPTION
This handles comments from https://github.com/careerbuilder/ruby-cb-api/pull/253 that included following our style guide more closely and returning the empty string when there is no errors node available in the error that we got back from the API.