### PR TITLE
Add Begin and End Date Times to Job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
-* 21.4.0 Add begin_date_time and end_date_time to Cb::Models::Job
+* 21.3.5 Add begin_date_time and end_date_time to Cb::Models::Job
 * 21.3.4 Code cleanup - no change in functionality
 * 21.3.3 Get whole error node, not just first. Check for 'Errors' instead of just 'errors'
 * 21.3.2 Follow style guide more closely and use `.first` + return empty string when no errors node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 21.4.0 Add begin_date_time and end_date_time to Cb::Models::Job
 * 21.3.4 Code cleanup - no change in functionality
 * 21.3.3 Get whole error node, not just first. Check for 'Errors' instead of just 'errors'
 * 21.3.2 Follow style guide more closely and use `.first` + return empty string when no errors node

--- a/lib/cb/models/implementations/job.rb
+++ b/lib/cb/models/implementations/job.rb
@@ -20,7 +20,7 @@ module Cb
                     :location, :distance, :latitude, :longitude, :location_formatted, :location_metro_city,
                     :description, :requirements, :employment_type,
                     :details_url, :service_url, :similar_jobs_url, :apply_url,
-                    :begin_date, :end_date, :posted_date, :posted_time, :posting_date,
+                    :begin_date, :begin_date_time, :end_date, :end_date_time, :posted_date, :posted_time, :posting_date,
                     :relevancy, :state, :city, :zip,
                     :can_be_quick_applied, :apply_requirements,
                     :divison, :industry, :location_street_1, :relocation_options, :location_street_2, :display_job_id,
@@ -156,7 +156,9 @@ module Cb
         @description                  = args['Description'] || args['JobDescription'] || ''
         @requirements                 = args['JobRequirements'] || ''
         @begin_date                   = args['BeginDate'] || ''
+        @begin_date_time              = args['BeginDateTime'] || ''
         @end_date                     = args['EndDate'] || ''
+        @end_date_time                = args['EndDateTime'] || ''
         @has_questionnaire            = args['HasQuestionnaire'] || ''
 
         # Application

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.3.4'
+  VERSION = '21.4.40
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.4.40
+  VERSION = '21.4.0
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.4.0'
+  VERSION = '21.3.5'
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.4.0
+  VERSION = '21.4.0'
 end

--- a/spec/cb/models/implementations/job_spec.rb
+++ b/spec/cb/models/implementations/job_spec.rb
@@ -22,6 +22,40 @@ module Cb::Models
           job = Job.new job_hash
           expect(job.apply_requirements).to eq(['noonlineapply'])
         end
+        
+        describe '#begin_date_time' do
+          subject { Job.new(job_hash).begin_date_time }
+          context 'BeginDateTime provided' do
+            let(:job_hash) do
+              { 'BeginDateTime' => '2016-05-26T03:59:59.0000000Z' }
+            end
+            it { is_expected.to eq '2016-05-26T03:59:59.0000000Z' }
+          end
+          
+          context 'BeginDateTime not provided' do
+            let(:job_hash) do
+              { }
+            end
+            it { is_expected.to eq '' }
+          end
+        end
+        
+        describe '#end_date_time' do
+          subject { Job.new(job_hash).end_date_time }
+          context 'EndDateTime provided' do
+            let(:job_hash) do
+              { 'EndDateTime' => '2016-05-26T03:59:59.0000000Z' }
+            end
+            it { is_expected.to eq '2016-05-26T03:59:59.0000000Z' }
+          end
+          
+          context 'EndDateTime not provided' do
+            let(:job_hash) do
+              { }
+            end
+            it { is_expected.to eq '' }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Presently the gem does not have accessors for this data it is already getting back from the API.  We need these fields to correct the posted within field on the new JDP.  Part of effort to fix CSI280515.