### PR TITLE
Ruby 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 21.4.1 Update test for Ruby 2.3.1. `ArgumentError`'s error message changed from "wrong number of arguments (0 for 1)" to "wrong number of arguments (given 0, expected 1)" in Ruby 2.3.0.
 * 21.4.0 Add jc_custom_fields to Cb::Models::Job
 * 21.3.5 Add begin_date_time and end_date_time to Cb::Models::Job
 * 21.3.4 Code cleanup - no change in functionality

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '21.4.0'
+  VERSION = '21.4.1'
 end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 CareerBuilder, LLC
+# Copyright 2016 CareerBuilder, LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,7 +20,9 @@ module Cb
 
       it 'requires a single param (external id)' do
         expect { Cb.user.temporary_password }.to raise_error(ArgumentError) do |arg_error|
-          expect(arg_error.message).to eq 'wrong number of arguments (0 for 1)'
+          # Ruby < 2.3.0 - "wrong number of arguments (0 for 1)"
+          # Ruby >= 2.3.0 - "wrong number of arguments (given 0, expected 1)"
+          expect(arg_error.message).to match /wrong number of arguments \((0 for 1|given 0, expected 1)\)/
         end
       end
 


### PR DESCRIPTION
Update test for compatibility with Ruby 2.3.1. `ArgumentError`'s error message changed from "wrong number of arguments (0 for 1)" to "wrong number of arguments (given 0, expected 1)" in Ruby 2.3.0.