### PR TITLE
Configure headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.1.0 Headers can be set on api instantiation.
 * 22.0.0 Return a hash from Job rather than a model
 * 21.4.2 Catch branding exceptions so that we don't blow up the job details call.  The side effect of a second API call is silly anyway
 * 21.4.1 Update test for Ruby 2.3.1. `ArgumentError`'s error message changed from "wrong number of arguments (0 for 1)" to "wrong number of arguments (given 0, expected 1)" in Ruby 2.3.0.

--- a/lib/cb/clients/base.rb
+++ b/lib/cb/clients/base.rb
@@ -12,8 +12,8 @@ module Cb
   module Clients
     class Base
       class << self
-        def cb_client
-          @cb_client ||= Cb::Utils::Api.instance
+        def cb_client(headers: {})
+          @cb_client ||= Cb::Utils::Api.instance(headers: headers)
         end
 
         def headers(args)

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -18,8 +18,8 @@ module Cb
 
       base_uri 'https://api.careerbuilder.com'
 
-      def self.instance
-        api = Cb::Utils::Api.new
+      def self.instance(headers: {})
+        api = Cb::Utils::Api.new(headers: headers)
         Cb.configuration.observers.each do |class_name|
           api.add_observer(class_name.new)
         end
@@ -29,13 +29,14 @@ module Cb
         api
       end
 
-      def initialize
+      def initialize(headers: {})
         self.class.default_params developerkey: Cb.configuration.dev_key,
                                   outputjson: Cb.configuration.use_json.to_s
 
         self.class.default_timeout Cb.configuration.time_out
         self.class.headers.merge! ({ 'developerkey' => Cb.configuration.dev_key })
         self.class.headers.merge! ({ 'accept-encoding' => 'deflate, gzip' }) unless Cb.configuration.debug_api
+        self.class.headers.merge! headers
       end
 
       def cb_get(path, options = {}, &block)

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.0.0'
+  VERSION = '22.1.0'
 end


### PR DESCRIPTION
This change will allow implementers to pass headers into the instantiation.  Please see the following example.
```Ruby
class TestClass < Base
  def TestClass.headers
    { accept: 'application/json' }
  end

  def TestClass.get
    cb_client(headers: headers)
    ...
  end
end
```