### PR TITLE
Adding back error checking and throwing on Job call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.0.1 Add error checking and raising back on Job call
 * 22.0.0 Return a hash from Job rather than a model
 * 21.4.2 Catch branding exceptions so that we don't blow up the job details call.  The side effect of a second API call is silly anyway
 * 21.4.1 Update test for Ruby 2.3.1. `ArgumentError`'s error message changed from "wrong number of arguments (0 for 1)" to "wrong number of arguments (given 0, expected 1)" in Ruby 2.3.0.

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -15,7 +15,7 @@ module Cb
       class << self
         def get(args={})
           response = cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
-          Cb::Responses::Errors.new(response)
+          Cb::Responses::Errors.new(response.fetch('ResponseJob')) unless response.nil?
           response
         end
       end

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -14,7 +14,9 @@ module Cb
     class Job < Base
       class << self
         def get(args={})
-          cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
+          response = cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
+          Errors.new(response)
+          response
         end
       end
     end

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -15,8 +15,16 @@ module Cb
       class << self
         def get(args={})
           response = cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
-          Cb::Responses::Errors.new(response.fetch('ResponseJob')) unless response.nil?
+          not_found_check(response)
           response
+        end
+        
+        private
+        
+        def not_found_check(response)
+          return if response.nil?
+          errors = Cb::Responses::Errors.new(response.fetch('ResponseJob'), false).parsed.join(',')
+          raise Cb::DocumentNotFoundError, errors if errors.downcase.include? 'job was not found'
         end
       end
     end

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -15,7 +15,7 @@ module Cb
       class << self
         def get(args={})
           response = cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
-          Errors.new(response)
+          Cb::Responses::Errors.new(response)
           response
         end
       end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.0.0'
+  VERSION = '22.0.1'
 end


### PR DESCRIPTION
So cool story. Not pushing the Job hash through the models skipped some error checking and throwing.  Added that back in.

After discussions with Jeff/Colin.  We decided to throw the 404 DocumentNotFoundError since the api should be returning 404 instead of 200.  Going to put in an AO ticket to have that api changed.