### PR TITLE
Recommendations client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.2.0 Add new Recommendations client (alongside existing Recommendation client) that returns a hash
 * 22.1.0 Headers can be set on api instantiation.
 * 22.0.0 Return a hash from Job rather than a model
 * 21.4.2 Catch branding exceptions so that we don't blow up the job details call.  The side effect of a second API call is silly anyway
@@ -79,6 +80,6 @@ Version History
 * 14.0.1 Introduced a changelog (finally)
 * 14.0.0 Rename location_code / zip to postal_code on the Cb::Models::User model to be more i18n friendly
 * 13.0.1 This change is to turn off metadata parsing and raise exception if the api response does not contain metadata.
-    * This means we can optionally control wether or not a specific API call expects metadata to come back   
+    * This means we can optionally control wether or not a specific API call expects metadata to come back
 * 13.0.0 Adds a new resume recommendations call and removes the old one *(BREAKING)*
     * https://github.com/careerbuilder/ruby-cb-api/pull/154/files

--- a/lib/cb/clients/recommendations.rb
+++ b/lib/cb/clients/recommendations.rb
@@ -22,9 +22,9 @@ module Cb
 
           {
             jobs: create_jobs(json_hash, 'Job'),
-            request: json_hash.dig('ResponseRecommendJob', 'Request'),
-            recid: json_hash.dig('ResponseRecommendJob', 'Request', 'RequestEvidenceID'),
-            errors: json_hash.dig('ResponseRecommendJob', 'Errors')
+            request: json_hash['ResponseRecommendJob']['Request'],
+            recid: json_hash['ResponseRecommendJob']['Request']['RequestEvidenceID'],
+            errors: json_hash['ResponseRecommendJob']['Errors']
           }
         end
 
@@ -36,9 +36,9 @@ module Cb
 
           {
             jobs: create_jobs(json_hash, 'User'),
-            request: json_hash.dig('ResponseRecommendUser', 'Request'),
-            recid: json_hash.dig('ResponseRecommendUser', 'Request', 'RequestEvidenceID'),
-            errors: json_hash.dig('ResponseRecommendUser', 'Errors')
+            request: json_hash['ResponseRecommendUser']['Request'],
+            recid: json_hash['ResponseRecommendUser']['Request']['RequestEvidenceID'],
+            errors: json_hash['ResponseRecommendUser']['Errors']
           }
         end
 

--- a/lib/cb/clients/recommendations.rb
+++ b/lib/cb/clients/recommendations.rb
@@ -62,13 +62,9 @@ module Cb
         end
 
         def create_jobs(json_hash, type)
-          jobs = []
-
-          [json_hash["ResponseRecommend#{type}"]['RecommendJobResults']['RecommendJobResult']].flatten.each do |api_job|
-            jobs << Models::Job.new(api_job)
+          [json_hash["ResponseRecommend#{type}"]['RecommendJobResults']['RecommendJobResult']].flatten.map do |api_job|
+            Models::Job.new(api_job)
           end
-
-          jobs
         end
       end
     end

--- a/lib/cb/clients/recommendations.rb
+++ b/lib/cb/clients/recommendations.rb
@@ -1,0 +1,76 @@
+# Copyright 2016 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'json'
+require_relative 'base'
+module Cb
+  module Clients
+    class Recommendations < Base
+      class << self
+        def for_job(*args)
+          hash_args = normalize_args(args)
+          hash_args = hash_defaults(hash_args)
+          json_hash = cb_client.cb_get(Cb.configuration.uri_recommendation_for_job,
+                                       query: hash_args)
+
+          {
+            jobs: create_jobs(json_hash, 'Job'),
+            request: json_hash.dig('ResponseRecommendJob', 'Request'),
+            recid: json_hash.dig('ResponseRecommendJob', 'Request', 'RequestEvidenceID'),
+            errors: json_hash.dig('ResponseRecommendJob', 'Errors')
+          }
+        end
+
+        def for_user(*args)
+          hash_args = normalize_args(args)
+          hash_args = hash_defaults(hash_args)
+          json_hash = cb_client.cb_get(Cb.configuration.uri_recommendation_for_user,
+                                       query: hash_args)
+
+          {
+            jobs: create_jobs(json_hash, 'User'),
+            request: json_hash.dig('ResponseRecommendUser', 'Request'),
+            recid: json_hash.dig('ResponseRecommendUser', 'Request', 'RequestEvidenceID'),
+            errors: json_hash.dig('ResponseRecommendUser', 'Errors')
+          }
+        end
+
+        private
+
+        def normalize_args(args)
+          return args[0] if args[0].class == Hash
+          {
+            ExternalID: args[0],
+            JobDID: args[0],
+            CountLimit: args[1] || '25',
+            SiteID: args[2] || '',
+            CoBrand: args[3] || ''
+          }
+        end
+
+        def hash_defaults(hash)
+          hash[:CountLimit] ||= '25'
+          hash[:HostSite] ||= Cb.configuration.host_site
+          hash
+        end
+
+        def create_jobs(json_hash, type)
+          jobs = []
+
+          [json_hash["ResponseRecommend#{type}"]['RecommendJobResults']['RecommendJobResult']].flatten.each do |api_job|
+            jobs << Models::Job.new(api_job)
+          end
+
+          jobs
+        end
+      end
+    end
+  end
+end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.1.0'
+  VERSION = '22.2.0'
 end

--- a/spec/cb/clients/recommendations_spec.rb
+++ b/spec/cb/clients/recommendations_spec.rb
@@ -14,7 +14,7 @@ require 'support/mocks/oauth_token'
 module Cb
   describe Cb::Clients::Recommendations do
     context '.for_job' do
-      before :each do
+      before do
         stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job))
           .to_return(body: { ResponseRecommendJob: { Request: { RequestEvidenceID: 'abc-123' }, RecommendJobResults: { RecommendJobResult: [{ did: 1 }, { did: 2 }] }, Errors: ['Error1', 'Error2'] } }.to_json)
       end
@@ -26,10 +26,20 @@ module Cb
       it { expect(recs[:recid]).to eq 'abc-123' }
       it { expect(recs[:jobs].count).to eq 2 }
       it { expect(recs[:jobs]).to all(be_a Cb::Models::Job) }
+
+      context 'with a single hash result' do
+        before do
+          stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job))
+            .to_return(body: { ResponseRecommendJob: { Request: { RequestEvidenceID: 'abc-123' }, RecommendJobResults: { RecommendJobResult: { did: 1 } }, Errors: ['Error1', 'Error2'] } }.to_json)
+        end
+
+        it { expect(recs[:jobs]).to be_an Array }
+
+      end
     end
 
     context '.for_user' do
-      before :each do
+      before do
         stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_user))
           .to_return(body: { ResponseRecommendUser: { Request: { RequestEvidenceID: 'abc-123' }, RecommendJobResults: { RecommendJobResult: [{ did: 1 }, { did: 2 }] }, Errors: ['Error1', 'Error2'] } }.to_json)
       end
@@ -41,6 +51,15 @@ module Cb
       it { expect(recs[:recid]).to eq 'abc-123' }
       it { expect(recs[:jobs].count).to eq 2 }
       it { expect(recs[:jobs]).to all(be_a Cb::Models::Job) }
+
+      context 'with a single hash result' do
+        before do
+          stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_user))
+          .to_return(body: { ResponseRecommendUser: { Request: { RequestEvidenceID: 'abc-123' }, RecommendJobResults: { RecommendJobResult: { did: 1 } }, Errors: ['Error1', 'Error2'] } }.to_json)
+        end
+
+        it { expect(recs[:jobs]).to be_an Array }
+      end
     end
   end
 end

--- a/spec/cb/clients/recommendations_spec.rb
+++ b/spec/cb/clients/recommendations_spec.rb
@@ -1,0 +1,46 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+require 'support/mocks/oauth_token'
+
+module Cb
+  describe Cb::Clients::Recommendations do
+    context '.for_job' do
+      before :each do
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job))
+          .to_return(body: { ResponseRecommendJob: { Request: { RequestEvidenceID: 'abc-123' }, RecommendJobResults: { RecommendJobResult: [{ did: 1 }, { did: 2 }] }, Errors: ['Error1', 'Error2'] } }.to_json)
+      end
+
+      subject(:recs) { Cb::Clients::Recommendations.for_job('fake-did') }
+
+      it { is_expected.to be_a Hash }
+      it { expect(recs[:errors]).to eq ['Error1', 'Error2'] }
+      it { expect(recs[:recid]).to eq 'abc-123' }
+      it { expect(recs[:jobs].count).to eq 2 }
+      it { expect(recs[:jobs]).to all(be_a Cb::Models::Job) }
+    end
+
+    context '.for_user' do
+      before :each do
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_user))
+          .to_return(body: { ResponseRecommendUser: { Request: { RequestEvidenceID: 'abc-123' }, RecommendJobResults: { RecommendJobResult: [{ did: 1 }, { did: 2 }] }, Errors: ['Error1', 'Error2'] } }.to_json)
+      end
+
+      subject(:recs) { Cb::Clients::Recommendations.for_user('U1234') }
+
+      it { is_expected.to be_a Hash }
+      it { expect(recs[:errors]).to eq ['Error1', 'Error2'] }
+      it { expect(recs[:recid]).to eq 'abc-123' }
+      it { expect(recs[:jobs].count).to eq 2 }
+      it { expect(recs[:jobs]).to all(be_a Cb::Models::Job) }
+    end
+  end
+end


### PR DESCRIPTION
Adds new client to return User and Job recommendations in a hash with the recid (and other metadata). We need this RecID field to start doing NDCG on recs calls.

Done side by side with existing code (which is in the poorly name Recommendation class) for a transition and to avoid the major version bump.