### PR TITLE
Fix recs NoMethodError for no-recs errors.

### DIFF
--- a/lib/cb/clients/recommendations.rb
+++ b/lib/cb/clients/recommendations.rb
@@ -65,6 +65,8 @@ module Cb
           [json_hash["ResponseRecommend#{type}"]['RecommendJobResults']['RecommendJobResult']].flatten.map do |api_job|
             Models::Job.new(api_job)
           end
+        rescue NoMethodError
+          []
         end
       end
     end

--- a/spec/cb/clients/recommendations_spec.rb
+++ b/spec/cb/clients/recommendations_spec.rb
@@ -36,6 +36,16 @@ module Cb
         it { expect(recs[:jobs]).to be_an Array }
 
       end
+
+      context 'with no recs' do
+        before do
+          stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job))
+            .to_return(body: { ResponseRecommendJob: { Request: { RequestEvidenceID: 'abc-123' }, Errors: ['Error1', 'Error2'] } }.to_json)
+        end
+
+        it { expect{ recs }.not_to raise_error }
+
+      end
     end
 
     context '.for_user' do
@@ -59,6 +69,16 @@ module Cb
         end
 
         it { expect(recs[:jobs]).to be_an Array }
+      end
+
+      context 'with no recs' do
+        before do
+          stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job))
+            .to_return(body: { ResponseRecommendUser: { Request: { RequestEvidenceID: 'abc-123' }, Errors: ['Error1', 'Error2'] } }.to_json)
+        end
+
+        it { expect{ recs }.not_to raise_error }
+
       end
     end
   end


### PR DESCRIPTION
Previous system used a bunch of `if hash.key? :key_name` nested 7 layers deep. I switched to `dig` then reverted to hash access for pre-2.3 compatibility.

This just rescues the NoMethodError from trying to build. Any exception here should really go to `[]`, but I figured on the smallest scope of change for now.