### PR TITLE
Migrate more calls to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.5.0 Add clients side-by-side existing requests.
 * 22.4.0 Add optional resume POST param: entry_path
-* 22.3.2 Add is_dynamic_screener to application form API 
+* 22.3.2 Add is_dynamic_screener to application form API
 * 22.3.1 Return an empty array for NoMethodError on recs.
 * 22.3.0 Update validator to handle errors node being nested in the response.
 * 22.2.1 Add error checking and raising back on Job call

--- a/lib/cb/clients/email_subscriptions.rb
+++ b/lib/cb/clients/email_subscriptions.rb
@@ -1,0 +1,67 @@
+# Copyright 2017 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
+module Cb
+  module Clients
+    class EmailSubscriptions < Base
+      class << self
+        def retrieve(args = {})
+          cb_client.cb_get(Cb.configuration.uri_subscription_retrieve, query: query(args), headers: headers(args))
+        end
+
+        def modify(args = {})
+          @unsubscribe_all = args[:unsubscribe_all]
+          cb_client.cb_post(Cb.configuration.uri_subscription_modify, body: body(args), headers: post_headers(args))
+        end
+
+        private
+
+        def query(args = {})
+          {
+            ExternalID: args[:external_id],
+            HostSite: args[:host_site] || Cb.configuration.host_site
+          }
+        end
+
+        def post_headers(args = {})
+          headers(args).merge('Content-Type' => 'application/xml')
+        end
+
+        def body(args = {})
+<<eos
+<Request>
+<DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+<ExternalID>#{args[:external_id]}</ExternalID>
+<Hostsite>#{args[:host_site] || Cb.configuration.host_site}</Hostsite>
+<CareerResources>#{validate args[:career_resources]}</CareerResources>
+<ProductSponsorInfo>#{validate args[:product_sponsor_info]}</ProductSponsorInfo>
+<ApplicantSurveyInvites>#{validate args[:applicant_survey_invites]}</ApplicantSurveyInvites>
+<JobRecs>#{validate args[:job_recs]}</JobRecs>
+<DJR>#{validate args[:djr]}</DJR>
+<ResumeViewed>#{validate args[:resume_viewed]}</ResumeViewed>
+<ApplicationViewed>#{validate args[:application_viewed]}</ApplicationViewed>
+<UnsubscribeAll>#{args[:unsubscribe_all]}</UnsubscribeAll>
+</Request>
+eos
+        end
+
+        def validate(value)
+          return value unless unsubscribe_all?
+          false.to_s
+        end
+
+        def unsubscribe_all?
+          @unsubscribe_all
+        end
+      end
+    end
+  end
+end

--- a/lib/cb/clients/email_subscriptions.rb
+++ b/lib/cb/clients/email_subscriptions.rb
@@ -13,11 +13,11 @@ module Cb
   module Clients
     class EmailSubscriptions < Base
       class << self
-        def retrieve(args = {})
+        def get(args = {})
           cb_client.cb_get(Cb.configuration.uri_subscription_retrieve, query: query(args), headers: headers(args))
         end
 
-        def modify(args = {})
+        def post(args = {})
           @unsubscribe_all = args[:unsubscribe_all]
           cb_client.cb_post(Cb.configuration.uri_subscription_modify, body: body(args), headers: post_headers(args))
         end

--- a/lib/cb/clients/email_subscriptions.rb
+++ b/lib/cb/clients/email_subscriptions.rb
@@ -36,21 +36,21 @@ module Cb
         end
 
         def body(args = {})
-<<eos
-<Request>
-<DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
-<ExternalID>#{args[:external_id]}</ExternalID>
-<Hostsite>#{args[:host_site] || Cb.configuration.host_site}</Hostsite>
-<CareerResources>#{validate args[:career_resources]}</CareerResources>
-<ProductSponsorInfo>#{validate args[:product_sponsor_info]}</ProductSponsorInfo>
-<ApplicantSurveyInvites>#{validate args[:applicant_survey_invites]}</ApplicantSurveyInvites>
-<JobRecs>#{validate args[:job_recs]}</JobRecs>
-<DJR>#{validate args[:djr]}</DJR>
-<ResumeViewed>#{validate args[:resume_viewed]}</ResumeViewed>
-<ApplicationViewed>#{validate args[:application_viewed]}</ApplicationViewed>
-<UnsubscribeAll>#{args[:unsubscribe_all]}</UnsubscribeAll>
-</Request>
-eos
+          <<-eos.gsub /^\s+/, ""
+          <Request>
+            <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+            <ExternalID>#{args[:external_id]}</ExternalID>
+            <Hostsite>#{args[:host_site] || Cb.configuration.host_site}</Hostsite>
+            <CareerResources>#{validate args[:career_resources]}</CareerResources>
+            <ProductSponsorInfo>#{validate args[:product_sponsor_info]}</ProductSponsorInfo>
+            <ApplicantSurveyInvites>#{validate args[:applicant_survey_invites]}</ApplicantSurveyInvites>
+            <JobRecs>#{validate args[:job_recs]}</JobRecs>
+            <DJR>#{validate args[:djr]}</DJR>
+            <ResumeViewed>#{validate args[:resume_viewed]}</ResumeViewed>
+            <ApplicationViewed>#{validate args[:application_viewed]}</ApplicationViewed>
+            <UnsubscribeAll>#{args[:unsubscribe_all]}</UnsubscribeAll>
+          </Request>
+          eos
         end
 
         def validate(value)

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -13,18 +13,34 @@ module Cb
   module Clients
     class Job < Base
       class << self
-        def get(args={})
+        def get(args = {})
           response = cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
           not_found_check(response)
           response
         end
-        
+
+        def report(args = {})
+          cb_client.cb_post(Cb.configuration.uri_report_job, body: report_body(args))
+        end
+
         private
-        
+
         def not_found_check(response)
           return if response.nil?
           errors = Cb::Responses::Errors.new(response['ResponseJob'], false).parsed.join
           raise Cb::DocumentNotFoundError, errors if errors.downcase.include? 'job was not found'
+        end
+
+        def report_body(args = {})
+          <<-eos
+          <Request>
+            <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+            <JobDID>#{args[:job_id]}</JobDID>
+            <UserID>#{args[:user_id]}</UserID>
+            <ReportType>#{args[:report_type]}</ReportType>
+            <Comments>#{args[:comments]}</Comments>
+          </Request>
+          eos
         end
       end
     end

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -32,7 +32,7 @@ module Cb
         end
 
         def report_body(args = {})
-          <<-eos
+          <<-eos.gsub /^\s+/, ""
           <Request>
             <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
             <JobDID>#{args[:job_id]}</JobDID>

--- a/lib/cb/clients/job_search.rb
+++ b/lib/cb/clients/job_search.rb
@@ -1,0 +1,37 @@
+# Copyright 2017 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require_relative 'base'
+module Cb
+  module Clients
+    class JobSearch < Base
+      class << self
+        def get(args = {})
+          cb_client.cb_get(Cb.configuration.uri_job_search, query: query(args), headers: headers(args))
+        end
+
+        private
+
+        def headers(args = {})
+          {
+             'Accept' => 'application/json;version=3.0',
+             'Authorization' => "Bearer #{ args[:oauth_token] }",
+             'Content-Type' => 'application/json',
+             'HostSite' => args[:host_site] || args[:HostSite] || Cb.configuration.host_site
+          }
+        end
+
+        def query(args = {})
+          args.reject { |k, _| k == :oauth_token }
+        end
+      end
+    end
+  end
+end

--- a/lib/cb/clients/resumes.rb
+++ b/lib/cb/clients/resumes.rb
@@ -28,7 +28,7 @@ module Cb
         end
 
         def put(args = {})
-          cb_client.cb_put(Cb.configuration.uri_resume_put.gsub(':resume_hash', args[:resume_hash].to_s), headers: headers(args), body: put_body(args)
+          cb_client.cb_put(Cb.configuration.uri_resume_put.gsub(':resume_hash', args[:resume_hash].to_s), headers: headers(args), body: put_body(args))
         end
 
         private

--- a/lib/cb/clients/resumes.rb
+++ b/lib/cb/clients/resumes.rb
@@ -27,6 +27,10 @@ module Cb
           cb_client.cb_delete(Cb.configuration.uri_resume_delete.sub(':resume_hash', args[:resume_hash].to_s), query: { externalUserId: args[:external_user_id] }, headers: headers(args))
         end
 
+        def put(args = {})
+          cb_client.cb_put(Cb.configuration.uri_resume_put.gsub(':resume_hash', args[:resume_hash].to_s), headers: headers(args), body: put_body(args)
+        end
+
         private
 
         def post_body(args = {})
@@ -45,6 +49,92 @@ module Cb
             'HostSite' => args[:host_site] || Cb.configuration.host_site,
             'Content-Type' => 'application/json;version=1.0',
             'Authorization' => "Bearer #{ args[:oauth_token] }"
+          }
+        end
+
+        def put_body(args = {})
+          {
+            userIdentifier: args[:user_identifier],
+            resumeHash: args[:resume_hash],
+            desiredJobTitle: args[:desired_job_title],
+            privacySetting: args[:privacy_setting],
+            workExperience: extract_work_experience(args),
+            salaryInformation: extract_salary_information(args),
+            educations: extract_educations(args),
+            skillsAndQualifications: extract_skills_and_qualifications(args),
+            relocations: extract_relocations(args),
+            governmentAndMilitary: extract_government_and_military(args)
+          }.to_json
+        end
+
+        def extract_work_experience(args = {})
+          return [] if args[:work_experience].blank?
+          args[:work_experience].map do |experience|
+            {
+              jobTitle: experience[:job_title],
+              companyName: experience[:company_name],
+              employmentType: experience[:employment_type],
+              startDate: experience[:start_date],
+              endDate: experience[:end_date],
+              currentlyEmployedHere: experience[:currently_employed_here],
+              id: experience[:id]
+            }
+          end
+        end
+
+        def extract_salary_information(args = {})
+          salary = args[:salary_information]
+          return {} if salary.blank?
+          {
+            mostRecentPayAmount: salary[:most_recent_pay_amount],
+            perHourOrPerYear: salary[:per_hour_or_per_year],
+            currencyCode: salary[:currency_code],
+            workExperienceId: salary[:work_experience_id],
+            annualBonus: salary[:annual_bonus],
+            annualCommission: salary[:annual_commission]
+          }
+        end
+
+        def extract_educations(args = {})
+          return [] if args[:educations].blank?
+          args[:educations].map do |education|
+            {
+              schoolName: education[:school_name],
+              majorOrProgram: education[:major_or_program],
+              degree: education[:degree],
+              graduationDate: education[:graduation_date]
+            }
+          end
+        end
+
+        def extract_skills_and_qualifications(args = {})
+          skills = args[:skills_and_qualifications]
+          return {} if skills.blank?
+          {
+            accreditationsAndCertifications: skills[:accreditations_and_certifications],
+            languagesSpoken: skills[:languages_spoken],
+            hasManagementExperience: skills[:has_management_experience],
+            sizeOfTeamManaged: skills[:size_of_team_managed]
+          }
+        end
+
+        def extract_relocations(args = {})
+          return [] unless args[:relocations]
+          args[:relocations].map do |relocate|
+            {
+              city: relocate[:city],
+              adminArea: relocate[:admin_area],
+              countryCode: relocate[:country_code]
+            }
+          end
+        end
+
+        def extract_government_and_military(args = {})
+          government = args[:government_and_military]
+          return {} if government.blank?
+          {
+            hasSecurityClearance: government[:has_security_clearance],
+            militaryExperience: government[:military_experience]
           }
         end
       end

--- a/lib/cb/clients/resumes.rb
+++ b/lib/cb/clients/resumes.rb
@@ -24,7 +24,7 @@ module Cb
         end
 
         def delete(args = {})
-          cb_client.cb_delete(Cb.configuration.uri_resume_delete.gsub(':resume_hash', args[:resume_hash].to_s), query: { externalUserId: args[:external_user_id] }, headers: headers(args))
+          cb_client.cb_delete(Cb.configuration.uri_resume_delete.sub(':resume_hash', args[:resume_hash].to_s), query: { externalUserId: args[:external_user_id] }, headers: headers(args))
         end
 
         private

--- a/lib/cb/clients/resumes.rb
+++ b/lib/cb/clients/resumes.rb
@@ -12,10 +12,41 @@ require_relative 'base'
 module Cb
   module Clients
     class Resumes < Base
-      def self.get(args={})
-        uri = Cb.configuration.uri_resumes
-        query_params = args[:site] ? { site: args[:site] } : { }
-        cb_client.cb_get(uri, headers: headers(args), query: query_params)
+      class << self
+        def get(args = {})
+          uri = Cb.configuration.uri_resumes
+          query_params = args[:site] ? { site: args[:site] } : {}
+          cb_client.cb_get(uri, headers: headers(args), query: query_params)
+        end
+
+        def post(args = {})
+          cb_client.cb_post(Cb.configuration.uri_resume_post, body: post_body(args), headers: headers(args))
+        end
+
+        def delete(args = {})
+          cb_client.cb_delete(Cb.configuration.uri_resume_delete.gsub(':resume_hash', args[:resume_hash].to_s), query: { externalUserId: args[:external_user_id] }, headers: headers(args))
+        end
+
+        private
+
+        def post_body(args = {})
+          {
+            desiredJobTitle: args[:desired_job_title],
+            privacySetting: args[:privacy_setting],
+            resumeFileData: args[:resume_file_data],
+            resumeFileName: args[:resume_file_name],
+            hostSite: args[:host_site],
+            entryPath: args[:entry_path]
+          }.to_json
+        end
+
+        def headers(args = {})
+          {
+            'HostSite' => args[:host_site] || args[:HostSite] || Cb.configuration.host_site,
+            'Content-Type' => 'application/json;version=1.0',
+            'Authorization' => "Bearer #{ args[:oauth_token] }"
+          }
+        end
       end
     end
   end

--- a/lib/cb/clients/resumes.rb
+++ b/lib/cb/clients/resumes.rb
@@ -42,7 +42,7 @@ module Cb
 
         def headers(args = {})
           {
-            'HostSite' => args[:host_site] || args[:HostSite] || Cb.configuration.host_site,
+            'HostSite' => args[:host_site] || Cb.configuration.host_site,
             'Content-Type' => 'application/json;version=1.0',
             'Authorization' => "Bearer #{ args[:oauth_token] }"
           }

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.4.0'
+  VERSION = '22.5.0'
 end

--- a/spec/cb/clients/email_subscriptions_spec.rb
+++ b/spec/cb/clients/email_subscriptions_spec.rb
@@ -64,7 +64,7 @@ module Cb
       let(:expected_body) do
 <<eos
 <Request>
-<DeveloperKey>ruby-cb-api</DeveloperKey>
+<DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
 <ExternalID>Uzer</ExternalID>
 <Hostsite>US</Hostsite>
 <CareerResources>false</CareerResources>
@@ -91,7 +91,7 @@ eos
         let(:expected_body) do
 <<eos
 <Request>
-<DeveloperKey>ruby-cb-api</DeveloperKey>
+<DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
 <ExternalID>Uzer</ExternalID>
 <Hostsite>US</Hostsite>
 <CareerResources>false</CareerResources>

--- a/spec/cb/clients/email_subscriptions_spec.rb
+++ b/spec/cb/clients/email_subscriptions_spec.rb
@@ -62,21 +62,21 @@ module Cb
           to_return(status: 200, body: {}.to_json)
       end
       let(:expected_body) do
-<<eos
-<Request>
-<DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
-<ExternalID>Uzer</ExternalID>
-<Hostsite>US</Hostsite>
-<CareerResources>false</CareerResources>
-<ProductSponsorInfo>true</ProductSponsorInfo>
-<ApplicantSurveyInvites>false</ApplicantSurveyInvites>
-<JobRecs>true</JobRecs>
-<DJR>true</DJR>
-<ResumeViewed>false</ResumeViewed>
-<ApplicationViewed>false</ApplicationViewed>
-<UnsubscribeAll>false</UnsubscribeAll>
-</Request>
-eos
+        <<-eos.gsub /^\s+/, ""
+        <Request>
+        <DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
+        <ExternalID>Uzer</ExternalID>
+        <Hostsite>US</Hostsite>
+        <CareerResources>false</CareerResources>
+        <ProductSponsorInfo>true</ProductSponsorInfo>
+        <ApplicantSurveyInvites>false</ApplicantSurveyInvites>
+        <JobRecs>true</JobRecs>
+        <DJR>true</DJR>
+        <ResumeViewed>false</ResumeViewed>
+        <ApplicationViewed>false</ApplicationViewed>
+        <UnsubscribeAll>false</UnsubscribeAll>
+        </Request>
+        eos
       end
 
       before do
@@ -89,21 +89,21 @@ eos
       context 'with unsubscribe_all true' do
         let(:params) { { oauth_token: 'token', external_id: 'Uzer', career_resources: true, unsubscribe_all: true } }
         let(:expected_body) do
-<<eos
-<Request>
-<DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
-<ExternalID>Uzer</ExternalID>
-<Hostsite>US</Hostsite>
-<CareerResources>false</CareerResources>
-<ProductSponsorInfo>false</ProductSponsorInfo>
-<ApplicantSurveyInvites>false</ApplicantSurveyInvites>
-<JobRecs>false</JobRecs>
-<DJR>false</DJR>
-<ResumeViewed>false</ResumeViewed>
-<ApplicationViewed>false</ApplicationViewed>
-<UnsubscribeAll>true</UnsubscribeAll>
-</Request>
-eos
+          <<-eos.gsub /^\s+/, ""
+          <Request>
+          <DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
+          <ExternalID>Uzer</ExternalID>
+          <Hostsite>US</Hostsite>
+          <CareerResources>false</CareerResources>
+          <ProductSponsorInfo>false</ProductSponsorInfo>
+          <ApplicantSurveyInvites>false</ApplicantSurveyInvites>
+          <JobRecs>false</JobRecs>
+          <DJR>false</DJR>
+          <ResumeViewed>false</ResumeViewed>
+          <ApplicationViewed>false</ApplicationViewed>
+          <UnsubscribeAll>true</UnsubscribeAll>
+          </Request>
+          eos
       end
 
         it { expect(stub).to have_been_requested }

--- a/spec/cb/clients/email_subscriptions_spec.rb
+++ b/spec/cb/clients/email_subscriptions_spec.rb
@@ -1,0 +1,113 @@
+# Copyright 2017 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module Cb
+  describe Cb::Clients::EmailSubscriptions do
+    describe '#get' do
+      subject { Cb::Clients::EmailSubscriptions.get(oauth_token: 'token', external_id: 'Uzer') }
+
+      let(:headers) do
+        {
+          'Accept' => 'application/json',
+          'Accept-Encoding' => 'deflate, gzip',
+          'Authorization' => 'Bearer token',
+          'Content-Type' => 'application/json',
+          'Developerkey' => Cb.configuration.dev_key
+        }
+      end
+
+      let(:uri) { "https://api.careerbuilder.com/v2/user/subscription/retrieve?ExternalID=Uzer&HostSite=US&developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+      let(:stub) do
+        stub_request(:get, uri).
+          with(headers: headers).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+    end
+
+    describe '#post' do
+      subject { Cb::Clients::EmailSubscriptions.post(params) }
+
+      let(:headers) do
+        {
+          'Accept' => 'application/json',
+          'Accept-Encoding' => 'deflate, gzip',
+          'Authorization' => 'Bearer token',
+          'Content-Type' => 'application/xml',
+          'Developerkey' => Cb.configuration.dev_key
+        }
+      end
+
+      let(:params) { { oauth_token: 'token', external_id: 'Uzer', career_resources: false, product_sponsor_info: true, applicant_survey_invites: false, job_recs: true, djr: true, resume_viewed: false, application_viewed: false, unsubscribe_all: false } }
+      let(:uri) { "https://api.careerbuilder.com/v2/user/subscription?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+      let(:stub) do
+        stub_request(:post, uri).
+          with(headers: headers, body: expected_body).
+          to_return(status: 200, body: {}.to_json)
+      end
+      let(:expected_body) do
+<<eos
+<Request>
+<DeveloperKey>ruby-cb-api</DeveloperKey>
+<ExternalID>Uzer</ExternalID>
+<Hostsite>US</Hostsite>
+<CareerResources>false</CareerResources>
+<ProductSponsorInfo>true</ProductSponsorInfo>
+<ApplicantSurveyInvites>false</ApplicantSurveyInvites>
+<JobRecs>true</JobRecs>
+<DJR>true</DJR>
+<ResumeViewed>false</ResumeViewed>
+<ApplicationViewed>false</ApplicationViewed>
+<UnsubscribeAll>false</UnsubscribeAll>
+</Request>
+eos
+      end
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+
+      context 'with unsubscribe_all true' do
+        let(:params) { { oauth_token: 'token', external_id: 'Uzer', career_resources: true, unsubscribe_all: true } }
+        let(:expected_body) do
+<<eos
+<Request>
+<DeveloperKey>ruby-cb-api</DeveloperKey>
+<ExternalID>Uzer</ExternalID>
+<Hostsite>US</Hostsite>
+<CareerResources>false</CareerResources>
+<ProductSponsorInfo>false</ProductSponsorInfo>
+<ApplicantSurveyInvites>false</ApplicantSurveyInvites>
+<JobRecs>false</JobRecs>
+<DJR>false</DJR>
+<ResumeViewed>false</ResumeViewed>
+<ApplicationViewed>false</ApplicationViewed>
+<UnsubscribeAll>true</UnsubscribeAll>
+</Request>
+eos
+      end
+
+        it { expect(stub).to have_been_requested }
+      end
+    end
+  end
+end

--- a/spec/cb/clients/job_search_spec.rb
+++ b/spec/cb/clients/job_search_spec.rb
@@ -1,0 +1,45 @@
+# Copyright 2017 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module Cb
+  describe Cb::Clients::JobSearch do
+    describe '#get' do
+      subject { Cb::Clients::JobSearch.get(oauth_token: 'token', keywords: 'Kanye West', location: 'Chi-town') }
+
+      let(:headers) do
+        {
+          'Accept' => 'application/json;version=3.0',
+          'Accept-Encoding' => 'deflate, gzip',
+          'Authorization' => 'Bearer token',
+          'Content-Type' => 'application/json',
+          'Developerkey' => Cb.configuration.dev_key,
+          'Hostsite' => 'US'
+        }
+      end
+
+      let(:uri) { "https://api.careerbuilder.com/consumer/jobs/search/?developerkey=#{ Cb.configuration.dev_key }&keywords=Kanye%20West&location=Chi-town&outputjson=true" }
+      let(:stub) do
+        stub_request(:get, uri).
+          with(headers: headers).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+    end
+  end
+end

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -39,5 +39,44 @@ module Cb
         it { expect{ Cb::Clients::Job.get(args) }.not_to raise_error Cb::DocumentNotFoundError }
       end
     end
+
+    describe '#report' do
+      subject { Cb::Clients::Job.report(params) }
+
+      let(:headers) do
+        {
+          'Accept-Encoding' => 'deflate, gzip',
+          'Developerkey' => Cb.configuration.dev_key
+        }
+      end
+
+      let(:params) { { job_id: 'job_id', user_id: 'user_id', report_type: 'report_type', comments: 'comments' } }
+      let(:uri) { "https://api.careerbuilder.com/v1/job/report?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+      let(:expected_body) do
+        <<-eos.gsub /^\s+/, ""
+        <Request>
+          <DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
+          <JobDID>job_id</JobDID>
+          <UserID>user_id</UserID>
+          <ReportType>report_type</ReportType>
+          <Comments>comments</Comments>
+        </Request>
+        eos
+      end
+
+      let(:stub) do
+        stub_request(:post, uri).
+          with(headers: headers, body: expected_body).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+    end
   end
 end

--- a/spec/cb/clients/resumes_spec.rb
+++ b/spec/cb/clients/resumes_spec.rb
@@ -14,10 +14,11 @@ module Cb
   describe Cb::Clients::Resumes do
     let(:headers) do
       {
-        'Accept' => 'application/json',
+        'Accept-Encoding' => 'deflate, gzip',
         'Authorization' => 'Bearer token',
-        'Content-Type' => 'application/json',
-        'Developerkey' => Cb.configuration.dev_key
+        'Content-Type' => 'application/json;version=1.0',
+        'Developerkey' => Cb.configuration.dev_key,
+        'HostSite' =>'US'
       }
     end
 

--- a/spec/cb/clients/resumes_spec.rb
+++ b/spec/cb/clients/resumes_spec.rb
@@ -51,5 +51,46 @@ module Cb
         it { is_expected.to eq api_response }
       end
     end
+
+    describe '#post' do
+      subject { Cb::Clients::Resumes.post(oauth_token: 'token', desired_job_title: 'Ur Mom', privacy_setting: 'Public', resume_file_data: 'DATA', resume_file_name: 'UrMom.doc', host_site: 'US', entry_path: 'WAT') }
+
+      let(:url) { "https://api.careerbuilder.com/consumer/resumedocuments?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+      let(:expected_body) do
+        "{\"desiredJobTitle\":\"Ur Mom\",\"privacySetting\":\"Public\",\"resumeFileData\":\"DATA\",\"resumeFileName\":\"UrMom.doc\",\"hostSite\":\"US\",\"entryPath\":\"WAT\"}"
+      end
+
+      let(:stub) do
+        stub_request(:post, url).
+          with(headers: headers, body: expected_body).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+    end
+
+    describe '#delete' do
+      subject { Cb::Clients::Resumes.delete(oauth_token: 'token', resume_hash: 'scattered_smothered_covered', external_user_id: 'Ext') }
+
+      let(:url) { "https://api.careerbuilder.com/cbapi/resumes/scattered_smothered_covered?developerkey=#{ Cb.configuration.dev_key }&externalUserId=Ext&outputjson=true" }
+
+      let(:stub) do
+        stub_request(:delete, url).
+          with(headers: headers).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+    end
   end
 end

--- a/spec/cb/clients/resumes_spec.rb
+++ b/spec/cb/clients/resumes_spec.rb
@@ -23,6 +23,8 @@ module Cb
     end
 
     describe '#get' do
+      subject { Cb::Clients::Resumes.get(oauth_token: 'token') }
+
       let(:uri) { "https://api.careerbuilder.com/consumer/resumes?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
       let(:api_response) { JSON.parse File.read('spec/support/response_stubs/resumes.json') }
       let(:stub) do
@@ -31,7 +33,6 @@ module Cb
           to_return(status: 200, body: api_response.to_json)
       end
 
-      subject { Cb::Clients::Resumes.get(oauth_token: 'token') }
 
       before do
         stub
@@ -91,6 +92,84 @@ module Cb
       end
 
       it { expect(stub).to have_been_requested }
+    end
+
+    describe '#put' do
+      subject { Cb::Clients::Resumes.put(params) }
+
+      let(:url) { "https://api.careerbuilder.com/cbapi/resumes/scattered_smothered_covered?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
+      let(:expected_body) do
+        '{"userIdentifier":"Thing","resumeHash":"scattered_smothered_covered","desiredJobTitle":"Ur Mom","privacySetting":"Public","workExperience":[],"salaryInformation":{},"educations":[],"skillsAndQualifications":{},"relocations":[],"governmentAndMilitary":{}}'
+      end
+      let(:params) { { user_identifier: 'Thing', oauth_token: 'token', desired_job_title: 'Ur Mom', privacy_setting: 'Public', host_site: 'US', resume_hash: 'scattered_smothered_covered' } }
+
+      let(:stub) do
+        stub_request(:put, url).
+          with(headers: headers, body: expected_body).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        stub
+        subject
+      end
+
+      it { expect(stub).to have_been_requested }
+
+      context 'with resume data' do
+        let(:params) do
+          {
+            user_identifier: 'Thing',
+            oauth_token: 'token',
+            desired_job_title: 'Ur Mom',
+            privacy_setting: 'Public',
+            host_site: 'US',
+            resume_hash: 'scattered_smothered_covered',
+            work_experience: [{
+              job_title: 'King',
+              company_name: 'Waffle House',
+              employment_type: 'Royal',
+              start_date: 'Beginning of Time',
+              end_date: 'Present',
+              currently_employed_here: true,
+              id: 1337
+            }],
+            salary_information: {
+              most_recent_pay_amount: '100 million',
+              per_hour_or_per_year: 'per_year',
+              current_code: 'USD',
+              work_experience_id: 1337,
+              annual_bonus: 'infinite',
+              annual_commission: 'hash browns'
+            },
+            educations: [{
+              school_name: 'School of Hard Knocks',
+              major_or_program: 'Life',
+              degree: 'Yes',
+              graduation_date: 'Ongoing'
+            }],
+            skills_and_qualifications: {
+              accreditations_and_certifications: 'All',
+              languages_spoken: 'Elvish, Elvisish',
+              has_management_experience: 'Yes',
+              size_of_team_managed: '6 billion'
+            },
+            relocations: [{
+              city: 'The Moon',
+              admin_area: 'The Moon',
+              country_code: 'MOON'
+            }],
+            government_and_military: {
+              has_security_clearance: true,
+              military_experience: 'commander in chief'
+            }
+          }
+        end
+
+        let(:expected_body) { "{\"userIdentifier\":\"Thing\",\"resumeHash\":\"scattered_smothered_covered\",\"desiredJobTitle\":\"Ur Mom\",\"privacySetting\":\"Public\",\"workExperience\":[{\"jobTitle\":\"King\",\"companyName\":\"Waffle House\",\"employmentType\":\"Royal\",\"startDate\":\"Beginning of Time\",\"endDate\":\"Present\",\"currentlyEmployedHere\":true,\"id\":1337}],\"salaryInformation\":{\"mostRecentPayAmount\":\"100 million\",\"perHourOrPerYear\":\"per_year\",\"currencyCode\":null,\"workExperienceId\":1337,\"annualBonus\":\"infinite\",\"annualCommission\":\"hash browns\"},\"educations\":[{\"schoolName\":\"School of Hard Knocks\",\"majorOrProgram\":\"Life\",\"degree\":\"Yes\",\"graduationDate\":\"Ongoing\"}],\"skillsAndQualifications\":{\"accreditationsAndCertifications\":\"All\",\"languagesSpoken\":\"Elvish, Elvisish\",\"hasManagementExperience\":\"Yes\",\"sizeOfTeamManaged\":\"6 billion\"},\"relocations\":[{\"city\":\"The Moon\",\"adminArea\":\"The Moon\",\"countryCode\":\"MOON\"}],\"governmentAndMilitary\":{\"hasSecurityClearance\":true,\"militaryExperience\":\"commander in chief\"}}" }
+
+        it { expect(stub).to have_been_requested }
+      end
     end
   end
 end


### PR DESCRIPTION
Adds clients alongside existing Request-type APIs. Goal here is to add them alongside for an easy transition, saving a major version bump w/ removal for when GRRP is no longer using it.