### PR TITLE
Add support for legacy (V2) job search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.6.0 Add legacy job search V2 endpoint
 * 22.5.0 Add clients side-by-side existing requests.
 * 22.4.0 Add optional resume POST param: entry_path
 * 22.3.2 Add is_dynamic_screener to application form API

--- a/lib/cb/clients/job_search.rb
+++ b/lib/cb/clients/job_search.rb
@@ -17,6 +17,11 @@ module Cb
           cb_client.cb_get(Cb.configuration.uri_job_search, query: query(args), headers: headers(args))
         end
 
+        def legacy_get(args = {})
+          options = query(args).merge(developerkey: Cb.configuration.dev_key)
+          cb_client.cb_get(Cb.configuration.uri_legacy_job_search, query: options)
+        end
+
         private
 
         def headers(args = {})

--- a/lib/cb/clients/job_search.rb
+++ b/lib/cb/clients/job_search.rb
@@ -18,8 +18,7 @@ module Cb
         end
 
         def legacy_get(args = {})
-          options = query(args).merge(developerkey: Cb.configuration.dev_key)
-          cb_client.cb_get(Cb.configuration.uri_legacy_job_search, query: options)
+          cb_client.cb_get(Cb.configuration.uri_legacy_job_search, query: query(args))
         end
 
         private

--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -68,6 +68,7 @@ module Cb
       @uri_job_find ||= '/v3/Job'
       @uri_job_insights ||= '/consumer/job-insights'
       @uri_job_search ||= '/consumer/jobs/search/'
+      @uri_legacy_job_search ||= '/v2/jobsearch'
       @uri_keyword_insights ||= '/consumer/insights/keywords'
       @uri_recommendation_for_job ||= '/v1/Recommendations/ForJob'
       @uri_recommendation_for_user ||= '/v1/Recommendations/ForUser'

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.5.0'
+  VERSION = '22.6.0'
 end

--- a/spec/cb/clients/job_search_spec.rb
+++ b/spec/cb/clients/job_search_spec.rb
@@ -44,7 +44,7 @@ module Cb
     describe '::legacy_get' do
       let(:uri) { "https://api.careerbuilder.com/v2/jobsearch?developerkey=#{ Cb.configuration.dev_key }&keywords=Ruby&location=Rubyland&outputjson=true" }
       let(:headers) do
-        { 'Accept-Encoding'=>'deflate, gzip', 'Developerkey'=> Cb.configuration.dev_key }
+        { 'Accept-Encoding' => 'deflate, gzip', 'Developerkey' => Cb.configuration.dev_key }
       end
 
       let!(:request_stub) do

--- a/spec/cb/clients/job_search_spec.rb
+++ b/spec/cb/clients/job_search_spec.rb
@@ -12,7 +12,12 @@ require 'spec_helper'
 
 module Cb
   describe Cb::Clients::JobSearch do
-    describe '#get' do
+    describe '::get' do
+      before do
+        request_stub
+        subject
+      end
+
       subject { Cb::Clients::JobSearch.get(oauth_token: 'token', keywords: 'Kanye West', location: 'Chi-town') }
 
       let(:headers) do
@@ -27,19 +32,31 @@ module Cb
       end
 
       let(:uri) { "https://api.careerbuilder.com/consumer/jobs/search/?developerkey=#{ Cb.configuration.dev_key }&keywords=Kanye%20West&location=Chi-town&outputjson=true" }
-      let(:stub) do
+      let(:request_stub) do
         stub_request(:get, uri).
           with(headers: headers).
           to_return(status: 200, body: {}.to_json)
       end
 
+      it { expect(request_stub).to have_been_requested }
+    end
 
-      before do
-        stub
-        subject
+    describe '::legacy_get' do
+      let(:uri) { "https://api.careerbuilder.com/v2/jobsearch?developerkey=#{ Cb.configuration.dev_key }&keywords=Ruby&location=Rubyland&outputjson=true" }
+      let(:headers) do
+        { 'Accept-Encoding'=>'deflate, gzip', 'Developerkey'=> Cb.configuration.dev_key }
       end
 
-      it { expect(stub).to have_been_requested }
+      let!(:request_stub) do
+        stub_request(:get, uri).
+          with(headers: headers).
+          to_return(status: 200, body: {}.to_json)
+      end
+
+      it do
+        Cb::Clients::JobSearch.legacy_get({ keywords: 'Ruby', location: 'Rubyland' })
+        expect(request_stub).to have_been_requested
+      end
     end
   end
 end

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -36,7 +36,7 @@ module Cb
 
       context 'not raise an error if errors node does not contain key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
-        it { expect{ Cb::Clients::Job.get(args) }.not_to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get(args) }.not_to raise_error }
       end
     end
 


### PR DESCRIPTION
Adds a tiny method to our job search client for performing dev-key powered job searches using /v2/jobsearch. 

Here's what usage looks like:
```ruby
Cb.configure do |config| 
  config.dev_key = 'your-devkey-here'
end

response = Cb::Clients::JobSearch.legacy_get(keywords: 'ruby', location: 'california')
# returns a hash that looks like this: 
{"ResponseJobSearch"=>
  {"Errors"=>nil,
   "TimeResponseSent"=>"5/3/2017 2:12:54 PM",
   "TimeElapsed"=>"0.2343696",
   "TotalPages"=>"6",
   "TotalCount"=>"138",
   # ....
}

# You can work with the individual results like this:
response['ResponseJobSearch']['Results']['JobSearchResult'].size
# => 25
response['ResponseJobSearch']['Results']['JobSearchResult'].first
{ "Company"=>"Blackstone Technology Group, Inc",
 "CompanyDID"=>"chq70977dghnf184l9v",
 "CompanyDetailsURL"=>"http://www.careerbuilder.com/jobs/company/chq70977dghnf184l9v/blackstone-technology-group-inc?sc_cmp1=13_JobRes_ComDet",
 "DID"=>"JGX7YZ75KH2LM11PWNK",
 "OnetCode"=>"15-1099.04",
 "ONetFriendlyTitle"=>"Web Developers",
 "ONet17Code"=>"15-1134.00",
 "ONet17FriendlyTitle"=>"Web Developers",
 "CaroteneV3Code"=>"15.65",
 "CaroteneV3FriendlyTitle"=>"na",
 "DescriptionTeaser"=>
  "Please note: U.S. Citizens and those authorizedto work in the U.S. are encouraged to apply."
  # ...
}
```