### PR TITLE
Replace resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.6.3 Added fields to update resume api call to allow replace resume
 * 22.6.2 Updating just to test rubygems publishing from travis
 * 22.6.1 Minor fixes on saved search tests.
 * 22.6.0 Move saved search create to new API. Request changes from XML to JSON.

--- a/lib/cb/clients/resumes.rb
+++ b/lib/cb/clients/resumes.rb
@@ -63,7 +63,10 @@ module Cb
             educations: extract_educations(args),
             skillsAndQualifications: extract_skills_and_qualifications(args),
             relocations: extract_relocations(args),
-            governmentAndMilitary: extract_government_and_military(args)
+            governmentAndMilitary: extract_government_and_military(args),
+            resumeFileData: args[:resume_file_data],
+            resumeFileName: args[:resume_file_name],
+            replaceEducationAndExperience: args[:replace_education_and_experience] == 'true'
           }.to_json
         end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.6.2'
+  VERSION = '22.6.3'
 end

--- a/spec/cb/clients/resumes_spec.rb
+++ b/spec/cb/clients/resumes_spec.rb
@@ -99,9 +99,9 @@ module Cb
 
       let(:url) { "https://api.careerbuilder.com/cbapi/resumes/scattered_smothered_covered?developerkey=#{ Cb.configuration.dev_key }&outputjson=true" }
       let(:expected_body) do
-        '{"userIdentifier":"Thing","resumeHash":"scattered_smothered_covered","desiredJobTitle":"Ur Mom","privacySetting":"Public","workExperience":[],"salaryInformation":{},"educations":[],"skillsAndQualifications":{},"relocations":[],"governmentAndMilitary":{}}'
+        '{"userIdentifier":"Thing","resumeHash":"scattered_smothered_covered","desiredJobTitle":"Ur Mom","privacySetting":"Public","workExperience":[],"salaryInformation":{},"educations":[],"skillsAndQualifications":{},"relocations":[],"governmentAndMilitary":{},"resumeFileData":"someFileData","resumeFileName":"someFileName","replaceEducationAndExperience":true}'
       end
-      let(:params) { { user_identifier: 'Thing', oauth_token: 'token', desired_job_title: 'Ur Mom', privacy_setting: 'Public', host_site: 'US', resume_hash: 'scattered_smothered_covered' } }
+      let(:params) { { user_identifier: 'Thing', oauth_token: 'token', desired_job_title: 'Ur Mom', privacy_setting: 'Public', host_site: 'US', resume_hash: 'scattered_smothered_covered', resume_file_data: 'someFileData', resume_file_name: 'someFileName', replace_education_and_experience: 'true' } }
 
       let(:stub) do
         stub_request(:put, url).
@@ -166,7 +166,7 @@ module Cb
           }
         end
 
-        let(:expected_body) { "{\"userIdentifier\":\"Thing\",\"resumeHash\":\"scattered_smothered_covered\",\"desiredJobTitle\":\"Ur Mom\",\"privacySetting\":\"Public\",\"workExperience\":[{\"jobTitle\":\"King\",\"companyName\":\"Waffle House\",\"employmentType\":\"Royal\",\"startDate\":\"Beginning of Time\",\"endDate\":\"Present\",\"currentlyEmployedHere\":true,\"id\":1337}],\"salaryInformation\":{\"mostRecentPayAmount\":\"100 million\",\"perHourOrPerYear\":\"per_year\",\"currencyCode\":null,\"workExperienceId\":1337,\"annualBonus\":\"infinite\",\"annualCommission\":\"hash browns\"},\"educations\":[{\"schoolName\":\"School of Hard Knocks\",\"majorOrProgram\":\"Life\",\"degree\":\"Yes\",\"graduationDate\":\"Ongoing\"}],\"skillsAndQualifications\":{\"accreditationsAndCertifications\":\"All\",\"languagesSpoken\":\"Elvish, Elvisish\",\"hasManagementExperience\":\"Yes\",\"sizeOfTeamManaged\":\"6 billion\"},\"relocations\":[{\"city\":\"The Moon\",\"adminArea\":\"The Moon\",\"countryCode\":\"MOON\"}],\"governmentAndMilitary\":{\"hasSecurityClearance\":true,\"militaryExperience\":\"commander in chief\"}}" }
+        let(:expected_body) { "{\"userIdentifier\":\"Thing\",\"resumeHash\":\"scattered_smothered_covered\",\"desiredJobTitle\":\"Ur Mom\",\"privacySetting\":\"Public\",\"workExperience\":[{\"jobTitle\":\"King\",\"companyName\":\"Waffle House\",\"employmentType\":\"Royal\",\"startDate\":\"Beginning of Time\",\"endDate\":\"Present\",\"currentlyEmployedHere\":true,\"id\":1337}],\"salaryInformation\":{\"mostRecentPayAmount\":\"100 million\",\"perHourOrPerYear\":\"per_year\",\"currencyCode\":null,\"workExperienceId\":1337,\"annualBonus\":\"infinite\",\"annualCommission\":\"hash browns\"},\"educations\":[{\"schoolName\":\"School of Hard Knocks\",\"majorOrProgram\":\"Life\",\"degree\":\"Yes\",\"graduationDate\":\"Ongoing\"}],\"skillsAndQualifications\":{\"accreditationsAndCertifications\":\"All\",\"languagesSpoken\":\"Elvish, Elvisish\",\"hasManagementExperience\":\"Yes\",\"sizeOfTeamManaged\":\"6 billion\"},\"relocations\":[{\"city\":\"The Moon\",\"adminArea\":\"The Moon\",\"countryCode\":\"MOON\"}],\"governmentAndMilitary\":{\"hasSecurityClearance\":true,\"militaryExperience\":\"commander in chief\"},\"resumeFileData\":null,\"resumeFileName\":null,\"replaceEducationAndExperience\":false}" }
 
         it { expect(stub).to have_been_requested }
       end


### PR DESCRIPTION
We added functionality to the update call on resume in the matrix to accept resumeFileData, resumeFileName, and replaceEducationAndExperience.  This PR adds these fields to the put request for GRRP.

![image](https://user-images.githubusercontent.com/971715/28135367-edc4e284-6713-11e7-945a-ceecfd42c42a.png)
