### PR TITLE
Replace Resume Fields Part Duex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.6.4 Added fields to the resume put object to allow replace resume
 * 22.6.3 Added fields to update resume api call to allow replace resume
 * 22.6.2 Updating just to test rubygems publishing from travis
 * 22.6.1 Minor fixes on saved search tests.

--- a/lib/cb/requests/resumes/put.rb
+++ b/lib/cb/requests/resumes/put.rb
@@ -41,7 +41,10 @@ module Cb
             educations: extract_educations,
             skillsAndQualifications: extract_skills_and_qualifications,
             relocations: extract_relocations,
-            governmentAndMilitary: extract_government_and_military
+            governmentAndMilitary: extract_government_and_military,
+            resumeFileData: args[:resume_file_data],
+            resumeFileName: args[:resume_file_name],
+            replaceEducationAndExperience: args[:replace_education_and_experience] == 'true'
           }.to_json
         end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.6.3'
+  VERSION = '22.6.4'
 end

--- a/spec/support/mocks/resume.rb
+++ b/spec/support/mocks/resume.rb
@@ -113,7 +113,10 @@ module Mocks
             {
               has_security_clearance: false,
               military_experience: ''
-            }
+            },
+          resumeFileData: nil,
+          resumeFileName: nil,
+          replaceEducationAndExperience: false
         }
       end
 
@@ -214,7 +217,10 @@ module Mocks
           'governmentAndMilitary' =>             {
             'hasSecurityClearance' => false,
             'militaryExperience' => ''
-          }
+          },
+          'resumeFileData' => nil,
+          'resumeFileName' => nil,
+          'replaceEducationAndExperience' => false
         }
       end
     end


### PR DESCRIPTION
We added functionality to the update call on resume in the matrix to accept resumeFileData, resumeFileName, and replaceEducationAndExperience.  This PR adds these fields to the put request for GRRP.

![image](https://user-images.githubusercontent.com/971715/28135367-edc4e284-6713-11e7-945a-ceecfd42c42a.png)
