### PR TITLE
Optionally Add Default Params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.7.0 Option to add default params to httparty calls
 * 22.6.4 Added fields to the resume put object to allow replace resume
 * 22.6.3 Added fields to update resume api call to allow replace resume
 * 22.6.2 Updating just to test rubygems publishing from travis

--- a/lib/cb/clients/base.rb
+++ b/lib/cb/clients/base.rb
@@ -12,8 +12,8 @@ module Cb
   module Clients
     class Base
       class << self
-        def cb_client(headers: {})
-          @cb_client ||= Cb::Utils::Api.instance(headers: headers)
+        def cb_client(headers: {}, use_default_params: true)
+          @cb_client ||= Cb::Utils::Api.instance(headers: headers, use_default_params: use_default_params)
         end
 
         def headers(args)

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -30,11 +30,7 @@ module Cb
       end
 
       def initialize(headers: {}, use_default_params: true)
-        if use_default_params
-          self.class.default_params developerkey: Cb.configuration.dev_key,
-                                    outputjson: Cb.configuration.use_json.to_s
-        end
-
+        self.class.default_params add_default_params if use_default_params
         self.class.default_timeout Cb.configuration.time_out
         h = { 'developerkey' => Cb.configuration.dev_key }
         h.merge! ({ 'accept-encoding' => 'deflate, gzip' }) unless Cb.configuration.debug_api
@@ -177,6 +173,13 @@ module Cb
       def format_hash_key(api_hash_key)
         return '' unless api_hash_key.respond_to?(:snakecase)
         api_hash_key.snakecase
+      end
+
+      def add_default_params
+        {
+            developerkey: Cb.configuration.dev_key,
+            outputjson: Cb.configuration.use_json.to_s
+        }
       end
     end
   end

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -18,8 +18,8 @@ module Cb
 
       base_uri 'https://api.careerbuilder.com'
 
-      def self.instance(headers: {})
-        api = Cb::Utils::Api.new(headers: headers)
+      def self.instance(headers: {}, use_default_params: true)
+        api = Cb::Utils::Api.new(headers: headers, use_default_params: use_default_params)
         Cb.configuration.observers.each do |class_name|
           api.add_observer(class_name.new)
         end
@@ -29,9 +29,11 @@ module Cb
         api
       end
 
-      def initialize(headers: {})
-        self.class.default_params developerkey: Cb.configuration.dev_key,
-                                  outputjson: Cb.configuration.use_json.to_s
+      def initialize(headers: {}, use_default_params: true)
+        if use_default_params
+          self.class.default_params developerkey: Cb.configuration.dev_key,
+                                    outputjson: Cb.configuration.use_json.to_s
+        end
 
         self.class.default_timeout Cb.configuration.time_out
         h = { 'developerkey' => Cb.configuration.dev_key }

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.6.4'
+  VERSION = '22.7.0'
 end

--- a/spec/cb/api_spec.rb
+++ b/spec/cb/api_spec.rb
@@ -14,6 +14,14 @@ describe Cb::Utils::Api do
   let(:api_util) { Cb::Utils::Api }
   
   context '#initialize' do
+    it 'does not set the default params' do
+      client = api_util.new(use_default_params: false)
+      expect(client.class.default_params).to eq({})
+    end
+    it 'sets the default params' do
+      client = api_util.new
+      expect(client.class.default_params).to eq({ developerkey: "ruby-cb-api", outputjson: "true" })
+    end
     it 'sets default gzip headers' do
       client = api_util.new
       expect(client.class.headers).to have_key('accept-encoding')


### PR DESCRIPTION
#### Problem:
Mahoneys team wants us to stop adding developerkey and outputjson to the url of the geo validation calls. My solution to this is to add an optional argument that defaults to true so that everything continues to work as normal. We can initialize the client in the geo client with 'use_default_params: false' so that it does not add these.

#### Staging on c-m with pre gems of ruby-cb-api and ruby-cb-api-internal:
http://insights-1.cbmtn.io/insights/assistant-store-manager?location=houston,tx

#### This is what the code in the internal gem will look like:
![image](https://user-images.githubusercontent.com/7825131/28923003-5bd5217c-782a-11e7-84d7-fb7be40565b1.png)
