### PR TITLE
Allow optional Accept header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 22.8.0 Allow optional override of Accept header
 * 22.7.0 Option to add default params to httparty calls
 * 22.6.4 Added fields to the resume put object to allow replace resume
 * 22.6.3 Added fields to update resume api call to allow replace resume

--- a/lib/cb/clients/base.rb
+++ b/lib/cb/clients/base.rb
@@ -16,9 +16,9 @@ module Cb
           @cb_client ||= Cb::Utils::Api.instance(headers: headers, use_default_params: use_default_params)
         end
 
-        def headers(args)
+        def headers(args, accept_header: 'application/json')
           {
-             'Accept' => 'application/json',
+             'Accept' => accept_header,
              'Authorization' => "Bearer #{ args[:oauth_token] }",
              'Content-Type' => 'application/json'
           }

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.7.0'
+  VERSION = '22.8.0'
 end

--- a/spec/cb/clients/base_client_spec.rb
+++ b/spec/cb/clients/base_client_spec.rb
@@ -1,0 +1,43 @@
+# Copyright 2017 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+require 'spec_helper'
+
+module Cb
+  describe Clients::Base do
+    context '::cb_client' do
+      it 'returns an instance of Cb::Utils::Api' do
+        expect(Cb::Clients::Base.cb_client).to be_a Cb::Utils::Api
+      end
+    end
+
+    context '::headers' do
+      it 'returns a hash of headers including Bearer token Authorization' do
+        headers = Cb::Clients::Base.headers(oauth_token: 'best_token')
+        expect(headers['Authorization']).to eq 'Bearer best_token'
+      end
+
+      it 'defaults Accept to application/json' do
+        headers = Cb::Clients::Base.headers({})
+        expect(headers['Accept']).to eq 'application/json'
+      end
+
+      it 'accepts an optional param to change Accept header' do
+        headers = Cb::Clients::Base.headers({}, accept_header: 'application/json;version=1.1')
+        expect(headers['Accept']).to eq 'application/json;version=1.1'
+      end
+
+      it 'defaults Content-Type to application/json' do
+        headers = Cb::Clients::Base.headers({})
+        expect(headers['Content-Type']).to eq 'application/json'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an optional parameter to the `Cb::Clients::Base.headers` method to allow overriding of the Accept header. 

It still defaults to the old value (application/json), but now if you pass in the kwarg `:accept_header` the headers that are returned will contain the value of the kwarg for the Accept header. The base client didn't have any tests so I did a quick, cheesy test for the `cb_client` method and then some more in depth tests that assert how the `headers` method works.