### PR TITLE
add oauth token as param for retrieval of job, bump major version

### DIFF
--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -13,8 +13,8 @@ module Cb
   module Clients
     class Job < Base
       class << self
-        def get(args = {})
-          response = cb_client.cb_get(Cb.configuration.uri_job_find, query: args)
+        def get(oauth_token, args = {})
+          response = cb_client.cb_get(Cb.configuration.uri_job_find, headers: headers(oauth_token), query: args)
           not_found_check(response)
           response
         end
@@ -24,6 +24,14 @@ module Cb
         end
 
         private
+
+        def headers(oauth_token)
+          {
+             'Accept' => 'application/json',
+             'Authorization' => "Bearer #{ oauth_token }",
+             'Content-Type' => 'application/json'
+          }
+        end
 
         def not_found_check(response)
           return if response.nil?

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -14,7 +14,7 @@ module Cb
     class Job < Base
       class << self
         def get(oauth_token, args = {})
-          response = cb_client.cb_get(Cb.configuration.uri_job_find, headers: headers(oauth_token), query: args)
+          response = cb_client.cb_get(uri_get(args[:did]), headers: headers(oauth_token), query: args)
           not_found_check(response)
           response
         end
@@ -24,6 +24,10 @@ module Cb
         end
 
         private
+
+        def uri_get job_id
+          "#{Cb.configuration.uri_job_find}/#{job_id}"
+        end
 
         def headers(oauth_token)
           {

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '22.10.0'
+  VERSION = '23.0.0'
 end

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -25,18 +25,18 @@ module Cb
       let(:args) { { did: 'someDID'} }
 
       it 'returns a hash' do
-        response = Cb::Clients::Job.get(args)
+        response = Cb::Clients::Job.get("token", args)
         expect(response).to be_a Hash
       end
 
       context 'raises an error if errors node contains key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was not found' } } }
-        it { expect{ Cb::Clients::Job.get(args) }.to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args) }.to raise_error Cb::DocumentNotFoundError }
       end
 
       context 'not raise an error if errors node does not contain key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
-        it { expect{ Cb::Clients::Job.get(args) }.not_to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args) }.not_to raise_error Cb::DocumentNotFoundError }
       end
     end
 


### PR DESCRIPTION
- changes `Cb::Clients::Job.get` to include oauth token as a parameter
- updates specs to pass in oauth token
- bump major version as this changes the method signature