### PR TITLE
Adding parameter to job get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 23.2.0 Add parameter for job get route
 * 23.0.1 Make did arg retrieval uppercase
 * 23.0.0 Add oauth token as param for retrieval of job
 * 22.10.0 Updated uri_job_find endpoint

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -13,8 +13,8 @@ module Cb
   module Clients
     class Job < Base
       class << self
-        def get(oauth_token, args = {}, consumer_job_details = false)
-          response = cb_client.cb_get(uri_get(args[:Did], consumer_job_details), headers: headers(oauth_token), query: args)
+        def get(oauth_token, args = {}, use_v3_endpoint = false)
+          response = cb_client.cb_get(uri_get(args[:Did], use_v3_endpoint), headers: headers(oauth_token), query: args)
           not_found_check(response)
           response
         end
@@ -25,11 +25,11 @@ module Cb
 
         private
 
-        def uri_get (job_id, consumer_job_details = false)
-          if consumer_job_details
-            "#{Cb.configuration.uri_job_find}/#{job_id}"
-          else
+        def uri_get (job_id, use_v3_endpoint)
+          if use_v3_endpoint
             Cb.configuration.uri_job_find_v3
+          else
+            "#{Cb.configuration.uri_job_find}/#{job_id}"
           end
         end
 

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -13,8 +13,8 @@ module Cb
   module Clients
     class Job < Base
       class << self
-        def get(oauth_token, args = {})
-          response = cb_client.cb_get(uri_get(args[:Did]), headers: headers(oauth_token), query: args)
+        def get(oauth_token, args = {}, use_v3_endpoint = true)
+          response = cb_client.cb_get(uri_get(args[:Did], use_v3_endpoint), headers: headers(oauth_token), query: args)
           not_found_check(response)
           response
         end
@@ -25,8 +25,12 @@ module Cb
 
         private
 
-        def uri_get job_id
-          "#{Cb.configuration.uri_job_find}/#{job_id}"
+        def uri_get (job_id, use_v3_endpoint = true)
+          if use_v3_endpoint
+            Cb.configuration.uri_job_find_v3
+          else
+            "#{Cb.configuration.uri_job_find}/#{job_id}"
+          end
         end
 
         def headers(oauth_token)

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -13,8 +13,8 @@ module Cb
   module Clients
     class Job < Base
       class << self
-        def get(oauth_token, args = {}, use_v3_endpoint = true)
-          response = cb_client.cb_get(uri_get(args[:Did], use_v3_endpoint), headers: headers(oauth_token), query: args)
+        def get(oauth_token, args = {}, consumer_job_details = false)
+          response = cb_client.cb_get(uri_get(args[:Did], consumer_job_details), headers: headers(oauth_token), query: args)
           not_found_check(response)
           response
         end
@@ -25,11 +25,11 @@ module Cb
 
         private
 
-        def uri_get (job_id, use_v3_endpoint = true)
-          if use_v3_endpoint
-            Cb.configuration.uri_job_find_v3
-          else
+        def uri_get (job_id, consumer_job_details = false)
+          if consumer_job_details
             "#{Cb.configuration.uri_job_find}/#{job_id}"
+          else
+            Cb.configuration.uri_job_find_v3
           end
         end
 

--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -66,6 +66,7 @@ module Cb
       @uri_job_branding ||= '/branding'
       @uri_job_expired ||= '/v1/job/expired'
       @uri_job_find ||= '/consumer/job/details'
+      @uri_job_find_v3 ||= 'v3/job'
       @uri_job_insights ||= '/consumer/job-insights'
       @uri_job_search ||= '/consumer/jobs/search/'
       @uri_keyword_insights ||= '/consumer/insights/keywords'

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module Cb
-  VERSION = '23.1.0'
+  VERSION = '23.2.0'
 end

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -50,18 +50,18 @@ module Cb
       let(:args) { { Did: 'someDID'} }
 
       it 'returns a hash' do
-        response = Cb::Clients::Job.get("token", args, true)
+        response = Cb::Clients::Job.get("token", args, false)
         expect(response).to be_a Hash
       end
 
       context 'raises an error if errors node contains key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was not found' } } }
-        it { expect{ Cb::Clients::Job.get("token", args, true) }.to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args, false) }.to raise_error Cb::DocumentNotFoundError }
       end
 
       context 'not raise an error if errors node does not contain key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
-        it { expect{ Cb::Clients::Job.get("token", args, true) }.not_to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args, false) }.not_to raise_error Cb::DocumentNotFoundError }
       end
     end
 

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -22,8 +22,6 @@ module Cb
           .to_return(body: response)
       end
 
-      let(:args) { { Did: 'someDID'} }
-
       it 'returns a hash' do
         response = Cb::Clients::Job.get("token", args)
         expect(response).to be_a Hash
@@ -37,6 +35,33 @@ module Cb
       context 'not raise an error if errors node does not contain key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
         it { expect{ Cb::Clients::Job.get("token", args) }.not_to raise_error Cb::DocumentNotFoundError }
+      end
+    end
+
+    describe '#getWithNewEndpoint' do
+      let(:response) { { ResponseJob: inner_nodes }.to_json }
+      let(:inner_nodes) { { Job: {} } }
+
+      before :each do
+        stub_request(:get, uri_stem(Cb.configuration.uri_job_find))
+            .to_return(body: response)
+      end
+
+      let(:args) { { Did: 'someDID'} }
+
+      it 'returns a hash' do
+        response = Cb::Clients::Job.get("token", args, false)
+        expect(response).to be_a Hash
+      end
+
+      context 'raises an error if errors node contains key phrase' do
+        let(:inner_nodes) { { Errors: { Error: 'job was not found' } } }
+        it { expect{ Cb::Clients::Job.get("token", args, false) }.to raise_error Cb::DocumentNotFoundError }
+      end
+
+      context 'not raise an error if errors node does not contain key phrase' do
+        let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
+        it { expect{ Cb::Clients::Job.get("token", args, false) }.not_to raise_error Cb::DocumentNotFoundError }
       end
     end
 

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -18,7 +18,7 @@ module Cb
       let(:inner_nodes) { { Job: {} } }
 
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_job_find))
+        stub_request(:get, uri_stem(Cb.configuration.uri_job_find_v3))
           .to_return(body: response)
       end
 

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -22,6 +22,9 @@ module Cb
           .to_return(body: response)
       end
 
+      let(:args) { { Did: 'someDID'} }
+
+
       it 'returns a hash' do
         response = Cb::Clients::Job.get("token", args, true)
         expect(response).to be_a Hash

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -23,18 +23,18 @@ module Cb
       end
 
       it 'returns a hash' do
-        response = Cb::Clients::Job.get("token", args)
+        response = Cb::Clients::Job.get("token", args, true)
         expect(response).to be_a Hash
       end
 
       context 'raises an error if errors node contains key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was not found' } } }
-        it { expect{ Cb::Clients::Job.get("token", args) }.to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args, true) }.to raise_error Cb::DocumentNotFoundError }
       end
 
       context 'not raise an error if errors node does not contain key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
-        it { expect{ Cb::Clients::Job.get("token", args) }.not_to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args, true) }.not_to raise_error Cb::DocumentNotFoundError }
       end
     end
 

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -50,18 +50,18 @@ module Cb
       let(:args) { { Did: 'someDID'} }
 
       it 'returns a hash' do
-        response = Cb::Clients::Job.get("token", args, false)
+        response = Cb::Clients::Job.get("token", args, true)
         expect(response).to be_a Hash
       end
 
       context 'raises an error if errors node contains key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was not found' } } }
-        it { expect{ Cb::Clients::Job.get("token", args, false) }.to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args, true) }.to raise_error Cb::DocumentNotFoundError }
       end
 
       context 'not raise an error if errors node does not contain key phrase' do
         let(:inner_nodes) { { Errors: { Error: 'job was found' } } }
-        it { expect{ Cb::Clients::Job.get("token", args, false) }.not_to raise_error Cb::DocumentNotFoundError }
+        it { expect{ Cb::Clients::Job.get("token", args, true) }.not_to raise_error Cb::DocumentNotFoundError }
       end
     end
 


### PR DESCRIPTION
This argument will determine which route to use for job details retrieval.  The argument defaults to false and will use the consumer/job/details endpoint by default. If you set the argument to true it will use the v3/job endpoint.